### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/plot_rsr.py
+++ b/plot_rsr.py
@@ -31,8 +31,8 @@ import numpy as np
 if __name__ == "__main__":
     import sys
     if len(sys.argv) < 4:
-        print("Usage: %s <platform_name> <sensor> <band name>" %
-              (sys.argv[0]))
+        print("Usage: {0!s} <platform_name> <sensor> <band name>".format(
+              (sys.argv[0])))
         exit(0)
 
     platform = str(sys.argv[1])


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:pytroll:pyspectral?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:pytroll:pyspectral?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)