### PR TITLE
Appdirs

### DIFF
--- a/pyspectral/config.py
+++ b/pyspectral/config.py
@@ -25,6 +25,8 @@
 
 import logging
 import os
+from os.path import expanduser
+from appdirs import AppDirs
 import yaml
 from collections import Mapping
 import pkg_resources
@@ -34,6 +36,7 @@ LOG = logging.getLogger(__name__)
 
 BUILTIN_CONFIG_FILE = pkg_resources.resource_filename(__name__,
                                                       os.path.join('etc', 'pyspectral.yaml'))
+
 
 CONFIG_FILE = os.environ.get('PSP_CONFIG_FILE')
 
@@ -70,5 +73,10 @@ def get_config():
     config = {}
     with open(configfile, 'r') as fp_:
         config = recursive_dict_update(config, yaml.load(fp_))
+
+    app_dirs = AppDirs('pyspectral', 'pytroll')
+    user_datadir = app_dirs.user_data_dir
+    config['rsr_dir'] = expanduser(config.get('rsr_dir', user_datadir))
+    config['rayleigh_dir'] = expanduser(config.get('rayleigh_dir', user_datadir))
 
     return config

--- a/pyspectral/etc/pyspectral.yaml
+++ b/pyspectral/etc/pyspectral.yaml
@@ -1,5 +1,11 @@
-rsr_dir: ~/.local/share/pyspectral/
-rayleigh_dir: ~/.local/share/pyspectral/
+#
+# Here you may overwrite the default PySpectral user data directories
+#
+#rsr_dir: ~/.local/share/pyspectral/
+#rayleigh_dir: ~/.local/share/pyspectral/
+
+# On default relative spectral responses and Rayleigh (atmospheric) correction
+# LUTs are downloaded from internet:
 download_from_internet: True
 
 path1: '/home/a000680/data/SpectralResponses/jpss1-viirs/J1_VIIRS_Detector_RSR_V2'

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -25,9 +25,7 @@
 
 import os
 import logging
-from os.path import expanduser
 import numpy as np
-from appdirs import AppDirs
 from pyspectral.config import get_config
 
 LOG = logging.getLogger(__name__)
@@ -121,12 +119,8 @@ HTTPS_RAYLEIGH_LUTS[
 
 
 CONF = get_config()
-
-DIRS = AppDirs('pyspectral', 'pytroll')
-USER_DATA_DIR = DIRS.user_data_dir
-LOCAL_RSR_DIR = expanduser(CONF.get('rsr_dir', USER_DATA_DIR))
-LOCAL_RAYLEIGH_DIR = expanduser(CONF.get('rayleigh_dir', USER_DATA_DIR))
-
+LOCAL_RSR_DIR = CONF.get('rsr_dir')
+LOCAL_RAYLEIGH_DIR = CONF.get('rayleigh_dir')
 
 try:
     os.makedirs(LOCAL_RSR_DIR)

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -27,7 +27,7 @@ import os
 import logging
 from os.path import expanduser
 import numpy as np
-
+from appdirs import AppDirs
 from pyspectral.config import get_config
 
 BANDNAMES = {'VIS006': 'VIS0.6',
@@ -106,8 +106,11 @@ HTTPS_RAYLEIGH_LUTS[
 
 CONF = get_config()
 
-LOCAL_RSR_DIR = expanduser(CONF['rsr_dir'])
-LOCAL_RAYLEIGH_DIR = expanduser(CONF['rayleigh_dir'])
+DIRS = AppDirs('pyspectral', 'pytroll')
+USER_DATA_DIR = DIRS.user_data_dir
+LOCAL_RSR_DIR = expanduser(CONF.get('rsr_dir', USER_DATA_DIR))
+LOCAL_RAYLEIGH_DIR = expanduser(CONF.get('rayleigh_dir', USER_DATA_DIR))
+
 
 try:
     os.makedirs(LOCAL_RSR_DIR)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ except IOError:
 requires = ['docutils>=0.3', 'numpy>=1.5.1', 'scipy>=0.14',
             'python-geotiepoints>=1.1.1',
             'h5py>=2.5', 'requests', 'tqdm', 'six', 'pyyaml',
-            'appdris']
+            'appdirs']
 
 test_requires = ['xlrd', 'pyyaml', 'matplotlib']
 if sys.version < '3.0':

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ except IOError:
 
 requires = ['docutils>=0.3', 'numpy>=1.5.1', 'scipy>=0.14',
             'python-geotiepoints>=1.1.1',
-            'h5py>=2.5', 'requests', 'tqdm', 'six', 'pyyaml']
+            'h5py>=2.5', 'requests', 'tqdm', 'six', 'pyyaml',
+            'appdris']
 
 test_requires = ['xlrd', 'pyyaml']
 if sys.version < '3.0':


### PR DESCRIPTION
Using AppDirs to automatically set the data directory (where rsr data files and atm correction LUTs will be stored) in a more platform independent way.

 - [ ] Tests passed
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff``
 - [ ] Fully documented
