### PR TITLE
Feature atmcorr without rsr

### DIFF
--- a/doc/rayleigh_correction.rst
+++ b/doc/rayleigh_correction.rst
@@ -1,5 +1,5 @@
-Rayleigh scattering correction
-------------------------------
+Atmospherioc correction in the visible spectrum
+-----------------------------------------------
 
 .. figure:: _static/truecolor_composite_20170518_nrk_reception_cropped_thumb.png
    :align: left
@@ -7,18 +7,19 @@ Rayleigh scattering correction
 
 In particular at the shorter wavelengths around :math:`400-600 nm`, which
 include the region used e.g. for ocean color products or true color imagery,
-the Rayleigh scattering due to atmospheric molecules or atoms becomes
-significant. As this atmospheric scattering is obscuring the retrieval of
+in particular the Rayleigh scattering due to atmospheric molecules or atoms,
+and Mie scattering and absorption of aerosols, becomes significant.
+As this atmospheric scattering and absorption is obscuring the retrieval of
 surface parameters and since it is strongly dependent on observation geometry,
 it is custom to try to correct or subtract this unwanted signal from the data
 before performing the geophysical retrieval.
 
-In order to correct for the Rayleigh scattering we have simulated the solar
+In order to correct for this atmospheric effect we have simulated the solar
 reflectance under various sun-satellite viewing conditions for a set of
-different standard atmospheres, using a radiative transfer model. For a given
-atmosphere the reflectance is dependent on wavelenght, solar-zenith angle,
-satellite zenith angle, and the relative sun-satellite azimuth difference
-angle:
+different standard atmospheres, asuming a black surface, using a radiative
+transfer model. For a given atmosphere the reflectance is dependent on wavelenght,
+solar-zenith angle, satellite zenith angle, and the relative sun-satellite
+azimuth difference angle:
 
 .. math::
 
@@ -34,18 +35,18 @@ in the figure below:
    :align: center
 
 
-To apply the rayleigh correction for a given satellite sensor band, the
+To apply the atmospheric correction for a given satellite sensor band, the
 procedure involves the following three steps:
 
  * Find the effective wavelength of the band
- * Derive the Rayleigh scattering part
+ * Derive the atmospheric absorption and scattering contribution
  * Subtract that from the observations
 
 As the Rayleigh scattering is proportional to :math:`\frac{1}{{\lambda}^4}` the
 effective wavelength is derived by convolving the spectral response with
 :math:`\frac{1}{{\lambda}^4}`. 
 
-To get the Rayleigh scattering contribution for an arbitrary band, first the
+To get the atmospheric contribution for an arbitrary band, first the
 solar zenith, satellite zenith and the sun-satellite azimuth difference angles
 should be loaded.
 
@@ -53,35 +54,64 @@ For the VIIRS M2 band the interface looks like this:
 
   >>> from pyspectral.rayleigh import Rayleigh
   >>> viirs = Rayleigh('Suomi-NPP', 'viirs')
+  >>> import numpy as np
+  >>> sunz = np.array([[32., 40.], [31., 41.]])
+  >>> satz = np.array([[45., 20.], [46., 21.]])
+  >>> ssadiff = np.array([[110, 170], [120, 180]])
   >>> refl_cor_m2 = viirs.get_reflectance(sunz, satz, ssadiff, 'M2')
+  >>> print(refl_cor_m2)
+  [[ 10.45746088   9.69434733]
+   [ 10.35336108   9.74561515]]
 
-This rayleigh contribution should then of course be subtracted from the
-data. Optionally the blueband can be provided as the fifth argument, which will
+This Rayleigh (including Mie scattering and aborption by aerosols) contribution
+should then of course be subtracted from the data.
+Optionally the red band can be provided as the fifth argument, which will
 provide a more gentle scaling in cases of high reflectances (above 20%):
 
-  >>> refl_cor_m2 = viirs.get_reflectance(sunz, satz, ssadiff, 'M2', blueband)
+  >>> redband =  np.array([[23., 19.], [24., 18.]])
+  >>> refl_cor_m2 = viirs.get_reflectance(sunz, satz, ssadiff, 'M2', redband)
+  >>> print(refl_cor_m2)
+  [[ 10.06530609   9.69434733]
+   [  9.83569303   9.74561515]]
 
-In case you do not know the name of the band (defined in the PySpectral rsr
-files) you can provide the approximate band frequency in micro meters:
+In case you want to bypass the reading of the sensor response functions or you have
+a sensor for which there are no RSR data available in PySpectral it is still possible
+to derive an atmospheric correction for that band. All what is needed is the effective
+wavelength of the band, given in micrometers (`:math: \mu m`). This wavelength is
+normally calculated by PySPectral from the RSR data when passing the name of the band
+as above.
 
-  >>> refl_cor_m2 = viirs.get_reflectance(sunz, satz, ssadiff, 0.45, blueband)
+  >>> from pyspectral.rayleigh import Rayleigh
+  >>> viirs = Rayleigh('UFO', 'ufo')
+  >>> import numpy as np
+  >>> sunz = np.array([[32., 40.], [31., 41.]])
+  >>> satz = np.array([[45., 20.], [46., 21.]])
+  >>> ssadiff = np.array([[110, 170], [120, 180]])
+  >>> refl_cor_m2 = viirs.get_reflectance(sunz, satz, ssadiff, 0.45, redband)
+  [[ 9.55453743  9.20336915]
+   [ 9.33705413  9.25222498]]
+
+You may choose any name for the platform and sensor as you like, as long as
+it does not match a platform/sensor pair for which RSR data exist in PySpectral.
 
 At the moment we have done simulations for a set of standard atmospheres in two
-different configuration, one only considering rayleigh scattering, and one also
-accounting for aerosols. On default we use the simulations without aerosol
-absorption, but it is possible to specify if you want the other setup, e.g.:
+different configurations, one only considering Rayleigh scattering, and one also
+accounting for Aerosols. On default we use the simulations with the marine-clean
+aerosol distribution and the US-standard atmosphere, but it is possible to specify
+if you want another setup, e.g.:
 
   >>> from pyspectral.rayleigh import Rayleigh
   >>> viirs = Rayleigh('Suomi-NPP', 'viirs', atmosphere='midlatitude summer', rural_aerosol=True)
-  >>> refl_cor_m2 = viirs.get_reflectance(sunz, satz, ssadiff, 0.45, blueband)
+  >>> refl_cor_m2 = viirs.get_reflectance(sunz, satz, ssadiff, 'M2', redband)
+  [[ 10.01281363   9.65488615]
+   [  9.78070046   9.70335278]]
+
+..
+   A few words on the radiative transfer simulations and LUTs
+   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
-A few words on the Rayleigh scattering simulations
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     .. image:: _static/refl_subarctic_winter_lambda_0400_ssa_000.png
 
-
-
-  .. image:: _static/refl_subarctic_winter_lambda_0400_ssa_000.png
-
-  .. image:: _static/refl_subarctic_winter_lambda_0500_ssa_090.png
+     .. image:: _static/refl_subarctic_winter_lambda_0500_ssa_090.png
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -41,7 +41,7 @@ A simple use case:
   Solar flux over Band: 2.002928
 
 And, here is how to derive the solar reflectance (removing the thermal part) of
-the Aqua MODIS 3.7 micron band::
+the Aqua MODIS 3.7 micron band:
 
   >>> from pyspectral.near_infrared_reflectance import Calculator
   >>> import numpy as np
@@ -53,8 +53,9 @@ the Aqua MODIS 3.7 micron band::
   Reflectance = 0.251249
 
 
-And, here is how to derive the rayleigh (with additional optional aerosol
-absorption) contribution in a short wave band:
+And, here is how to derive the atmospheric (Rayleigh scattering by atmospheric
+molecules and atoms as well as Mie scattering and absorption of aerosols)
+contribution in a short wave band:
 
   >>> from pyspectral import rayleigh
   >>> rcor = rayleigh.Rayleigh('GOES-16', 'abi')
@@ -62,9 +63,10 @@ absorption) contribution in a short wave band:
   >>> sunz = np.array([[50., 60.], [51., 61.]])
   >>> satz = np.array([[40., 50.], [41., 51.]])
   >>> azidiff = np.array([[160, 160], [160, 160]])
-  >>> blueband =  np.array([[0.1, 0.15], [0.11, 0.16]])
-  >>> print(rcor.get_reflectance(sunz, satz, azidiff, 'ch2', blueband))
-  [[ 2.01927932  3.20415785]
-   [ 2.08904394  3.41731944]]
+  >>> redband =  np.array([[0.1, 0.15], [0.11, 0.16]])
+  >>> print(rcor.get_reflectance(sunz, satz, azidiff, 'ch2', redband))
+  [[ 3.25463676  6.48864479]
+   [ 3.4343512   7.12155557]]
+
 
 

--- a/pyspectral/rayleigh.py
+++ b/pyspectral/rayleigh.py
@@ -21,8 +21,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Rayleigh correction of shortwave imager bands in the wavelength range 400 to
-800 nm
+"""Atmospheric correction of shortwave imager bands in the wavelength range 400
+to 800 nm
 
 """
 
@@ -61,8 +61,9 @@ class BandFrequencyOutOfRange(Exception):
 
 class Rayleigh(object):
 
-    """Container for the Rayleigh scattering correction of satellite imager short
-    wave bands
+    """Container for the atmospheric correction of satellite imager short
+    wave bands. Removing background contributions of Rayleigh scattering of
+    molecules and Mie scattering and absorption by aerosols.
 
     """
 
@@ -71,12 +72,12 @@ class Rayleigh(object):
         self.sensor = sensor
         self.coeff_filename = None
 
-        atm_type = kwargs.get('atmosphere', 'subarctic summer')
+        atm_type = kwargs.get('atmosphere', 'us-standard')
         if atm_type not in ATMOSPHERES:
             raise AttributeError('Atmosphere type not supported! ' +
                                  'Need to be one of {}'.format(str(ATMOSPHERES)))
 
-        aerosol_type = kwargs.get('aerosol_type', 'rayleigh_only')
+        aerosol_type = kwargs.get('aerosol_type', 'marine_clean_aerosol')
 
         if aerosol_type not in AEROSOL_TYPES:
             raise AttributeError('Aerosol type not supported! ' +

--- a/pyspectral/tests/test_rayleigh.py
+++ b/pyspectral/tests/test_rayleigh.py
@@ -42,7 +42,7 @@ from pyspectral.tests.data import (
 
 TEST_RAYLEIGH_RESULT1 = np.array([10.40727436,   8.69775471], dtype='float32')
 TEST_RAYLEIGH_RESULT2 = np.array([9.71695252,  8.51415601], dtype='float32')
-TEST_RAYLEIGH_RESULT3 = np.array([10.03301932,   8.75922375], dtype='float32')
+TEST_RAYLEIGH_RESULT3 = np.array([5.61532271,  8.69267476], dtype='float32')
 
 
 import os
@@ -216,10 +216,10 @@ class TestRayleigh(unittest.TestCase):
             instance.rsr = None
             instance.unit = '1e-6 m'
             instance.si_scale = 1e-6
-            sun_zenith = np.array([60., 20.])
-            sat_zenith = np.array([49., 26.])
-            azidiff = np.array([140., 130.])
-            blueband = np.array([12., 8.])
+            sun_zenith = np.array([50., 10.])
+            sat_zenith = np.array([39., 16.])
+            azidiff = np.array([170., 110.])
+            blueband = np.array([29., 12.])
             ufo = rayleigh.Rayleigh('UFO', 'unknown')
 
             retv = ufo.get_reflectance(sun_zenith, sat_zenith, azidiff, 0.441, blueband)

--- a/pyspectral/tests/test_rayleigh.py
+++ b/pyspectral/tests/test_rayleigh.py
@@ -42,6 +42,7 @@ from pyspectral.tests.data import (
 
 TEST_RAYLEIGH_RESULT1 = np.array([10.40727436,   8.69775471], dtype='float32')
 TEST_RAYLEIGH_RESULT2 = np.array([9.71695252,  8.51415601], dtype='float32')
+TEST_RAYLEIGH_RESULT3 = np.array([10.03301932,   8.75922375], dtype='float32')
 
 
 import os
@@ -191,6 +192,38 @@ class TestRayleigh(unittest.TestCase):
         blueband = np.array([12., 8.])
         retv = self.viirs_rayleigh.get_reflectance(sun_zenith, sat_zenith, azidiff, 'M2', blueband)
         self.assertTrue(np.allclose(retv, TEST_RAYLEIGH_RESULT2))
+
+    @patch('os.path.exists')
+    @patch('pyspectral.utils.download_luts')
+    @patch('pyspectral.rayleigh.get_reflectance_lut')
+    def test_get_reflectance_no_rsr(self, get_reflectance_lut, download_luts, exists):
+        """Test getting the reflectance correction, simulating that we have no RSR data"""
+
+        rayl = TEST_RAYLEIGH_LUT
+        wvl_coord = TEST_RAYLEIGH_WVL_COORD
+        azid_coord = TEST_RAYLEIGH_AZID_COORD
+        sunz_sec_coord = TEST_RAYLEIGH_SUNZ_COORD
+        satz_sec_coord = TEST_RAYLEIGH_SATZ_COORD
+
+        get_reflectance_lut.return_value = (rayl, wvl_coord, azid_coord,
+                                            satz_sec_coord, sunz_sec_coord)
+        download_luts.return_code = None
+        exists.return_code = True
+
+        with patch('pyspectral.rayleigh.RelativeSpectralResponse') as mymock:
+            instance = mymock.return_value
+            mymock.side_effect = IOError("No rsr data in pyspectral for this platform and sensor")
+            instance.rsr = None
+            instance.unit = '1e-6 m'
+            instance.si_scale = 1e-6
+            sun_zenith = np.array([60., 20.])
+            sat_zenith = np.array([49., 26.])
+            azidiff = np.array([140., 130.])
+            blueband = np.array([12., 8.])
+            ufo = rayleigh.Rayleigh('UFO', 'unknown')
+
+            retv = ufo.get_reflectance(sun_zenith, sat_zenith, azidiff, 0.441, blueband)
+            self.assertTrue(np.allclose(retv, TEST_RAYLEIGH_RESULT3))
 
     def tearDown(self):
         """Clean up"""


### PR DESCRIPTION
We needed a way to derive atmospheric corrections without having access to the spectral responses (RSR data). This was actually already possible, but it was undocumented and no unit test was testing it. This should now be fixed.

 - [x] Closes #26 
 - [x] Tests added
 - [x] Tests passed
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff``
 - [x] Fully documented
