### PR TITLE
change pylab calls to OO pyplot calls. Fixes #30

### DIFF
--- a/pyspectral/solar.py
+++ b/pyspectral/solar.py
@@ -263,7 +263,6 @@ class SolarIrradianceSpectrum(object):
         fig, axl = plt.subplots(figsize=(8, 4))
         plot_title = "Solar Irradiance Spectrum"
         axl.set_title(plot_title)
-        # axl = fig.add_subplot(111)
 
         axl.plot(xwl, yir, '-', color=color)
 

--- a/pyspectral/solar.py
+++ b/pyspectral/solar.py
@@ -89,7 +89,7 @@ class SolarIrradianceSpectrum(object):
 
     def convert2wavenumber(self):
         """
-        Convert from wavelengths to wavenumber. 
+        Convert from wavelengths to wavenumber.
 
         Units:
           Wavelength: micro meters (1e-6 m)
@@ -255,25 +255,25 @@ class SolarIrradianceSpectrum(object):
         else:
             raise TypeError('Neither wavelengths nor wavenumbers available!')
 
-        import pylab
+        from matplotlib import pyplot as plt
         from matplotlib import rcParams
         rcParams['text.usetex'] = True
         rcParams['text.latex.unicode'] = True
 
-        fig = pylab.figure(figsize=(8, 4))
+        fig, axl = plt.subplots(figsize=(8, 4))
         plot_title = "Solar Irradiance Spectrum"
-        pylab.title(plot_title)
-        axl = fig.add_subplot(111)
+        axl.set_title(plot_title)
+        # axl = fig.add_subplot(111)
 
         axl.plot(xwl, yir, '-', color=color)
 
-        pylab.xlabel(xlabel)
-        pylab.ylabel(ylabel)
-        pylab.xlim(xlim)
-        pylab.ylim([0, yir.max()])
+        axl.set_xlabel(xlabel)
+        axl.set_ylabel(ylabel)
+        axl.set_xlim(xlim)
+        axl.set_ylim([0, yir.max()])
         axl.grid(True)
 
         if plotname is None:
-            pylab.show()
+            plt.show()
         else:
             fig.savefig(plotname)


### PR DESCRIPTION
When using solar.SolarIrradianceSpectrum.plot() I got some weird deprecation warnings, possibly simply from the use of becoming obsolete pylab interface.
Because the OO interface via pyplot is much more secure and readable (not state-dependent!), I thought a change to that way of plotting is a good improvement.

 - [x] Closes #30 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->


3 tests currently fail, but that can't be me??

```bash
======================================================================
FAIL: /Users/klay6683/Dropbox/src/pyspectral/pyspectral/tests/../../doc/usage.rst
Doctest: usage.rst
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/klay6683/miniconda3/envs/stable/lib/python3.6/doctest.py", line 2199, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for usage.rst
  File "/Users/klay6683/Dropbox/src/pyspectral/pyspectral/tests/../../doc/usage.rst", line 0

----------------------------------------------------------------------
File "/Users/klay6683/Dropbox/src/pyspectral/pyspectral/tests/../../doc/usage.rst", line 67, in usage.rst
Failed example:
    print(rcor.get_reflectance(sunz, satz, azidiff, 'ch2', redband))
Expected:
    [[ 3.25463676  6.48864479]
     [ 3.4343512   7.12155557]]
Got:
    [[3.25463676 6.48864479]
     [3.4343512  7.12155557]]


======================================================================
FAIL: /Users/klay6683/Dropbox/src/pyspectral/pyspectral/tests/../../doc/rad_definitions.rst
Doctest: rad_definitions.rst
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/klay6683/miniconda3/envs/stable/lib/python3.6/doctest.py", line 2199, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for rad_definitions.rst
  File "/Users/klay6683/Dropbox/src/pyspectral/pyspectral/tests/../../doc/rad_definitions.rst", line 0

----------------------------------------------------------------------
File "/Users/klay6683/Dropbox/src/pyspectral/pyspectral/tests/../../doc/rad_definitions.rst", line 86, in rad_definitions.rst
Failed example:
    print(get_central_wave(seviri.rsr['VIS0.6']['det-1']['wavelength'], seviri.rsr['VIS0.6']['det-1']['response']))
Expected:
    0.640216
Got:
    0.6402156
----------------------------------------------------------------------
File "/Users/klay6683/Dropbox/src/pyspectral/pyspectral/tests/../../doc/rad_definitions.rst", line 160, in rad_definitions.rst
Failed example:
    print(solar_irr.solar_constant())
Expected:
    1366077.16482
Got:
    1366077.1648199116
----------------------------------------------------------------------
File "/Users/klay6683/Dropbox/src/pyspectral/pyspectral/tests/../../doc/rad_definitions.rst", line 268, in rad_definitions.rst
Failed example:
    print(temp)
Expected:
    [ 299.99998562  301.00000518]
Got:
    [299.99998562 301.00000518]


======================================================================
FAIL: /Users/klay6683/Dropbox/src/pyspectral/pyspectral/tests/../../doc/37_reflectance.rst
Doctest: 37_reflectance.rst
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/klay6683/miniconda3/envs/stable/lib/python3.6/doctest.py", line 2199, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for 37_reflectance.rst
  File "/Users/klay6683/Dropbox/src/pyspectral/pyspectral/tests/../../doc/37_reflectance.rst", line 0

----------------------------------------------------------------------
File "/Users/klay6683/Dropbox/src/pyspectral/pyspectral/tests/../../doc/37_reflectance.rst", line 48, in 37_reflectance.rst
Failed example:
    rad37['radiance'].data
Expected:
    array([ 369717.47657257,  355110.5207853 ,  314684.27887262,
            173143.54248984,  116408.00078766])
Got:
    array([369717.47657257, 355110.52078527, 314684.27887262, 173143.54248984,
           116408.00078766])
----------------------------------------------------------------------
File "/Users/klay6683/Dropbox/src/pyspectral/pyspectral/tests/../../doc/37_reflectance.rst", line 62, in 37_reflectance.rst
Failed example:
    rad37['radiance'].data
Expected:
    array([ 0.07037968,  0.06759909,  0.05990352,  0.03295972,  0.02215951])
Got:
    array([0.07037968, 0.06759909, 0.05990352, 0.03295972, 0.02215951])
----------------------------------------------------------------------
File "/Users/klay6683/Dropbox/src/pyspectral/pyspectral/tests/../../doc/37_reflectance.rst", line 73, in 37_reflectance.rst
Failed example:
    viirs.rsr_integral
Expected:
    1.9036069e-07
Got:
    1.903607e-07
----------------------------------------------------------------------
File "/Users/klay6683/Dropbox/src/pyspectral/pyspectral/tests/../../doc/37_reflectance.rst", line 202, in 37_reflectance.rst
Failed example:
    m12r
Expected:
    masked_array(data = [ 0.21432927  0.20285153  0.17063976  0.05408903  0.00838111],
                 mask = False,
           fill_value = 1e+20)
    <BLANKLINE>
Got:
    masked_array(data=[0.21432927, 0.20285153, 0.17063976, 0.05408903,
                       0.00838111],
                 mask=False,
           fill_value=1e+20)
----------------------------------------------------------------------
File "/Users/klay6683/Dropbox/src/pyspectral/pyspectral/tests/../../doc/37_reflectance.rst", line 221, in 37_reflectance.rst
Failed example:
    nomin
Expected:
    masked_array(data = [0.050836774216986104 0.04805618397143852 0.040415704457706314
     0.012792786724811864 0.0020448525399977963],
                 mask = [False False False False False],
           fill_value = 1e+20)
    <BLANKLINE>
Got:
    masked_array(data=[0.050836774216986104, 0.048056183971431805,
                       0.040415704457706314, 0.012792786724811864,
                       0.0020448525399977963],
                 mask=[False, False, False, False, False],
           fill_value=1e+20)
----------------------------------------------------------------------
File "/Users/klay6683/Dropbox/src/pyspectral/pyspectral/tests/../../doc/37_reflectance.rst", line 228, in 37_reflectance.rst
Failed example:
    denom
Expected:
    masked_array(data = [0.2364631285385081 0.2364568193006244 0.2365055918405679
     0.23582014534666546 0.23586610035551708],
                 mask = [False False False False False],
           fill_value = 1e+20)
    <BLANKLINE>
Got:
    masked_array(data=[0.2364631285385081, 0.2364568193006244,
                       0.2365055918405679, 0.23582014534666546,
                       0.23586610035551708],
                 mask=[False, False, False, False, False],
           fill_value=1e+20)
----------------------------------------------------------------------
File "/Users/klay6683/Dropbox/src/pyspectral/pyspectral/tests/../../doc/37_reflectance.rst", line 234, in 37_reflectance.rst
Failed example:
    nomin/denom
Expected:
    masked_array(data = [0.21498816551734543 0.2032345022384035 0.17088688746501676
     0.05424806564344167 0.008669548260286764],
                 mask = [False False False False False],
           fill_value = 1e+20)
    <BLANKLINE>
Got:
    masked_array(data=[0.21498816551734543, 0.2032345022383751,
                       0.17088688746501676, 0.05424806564344167,
                       0.008669548260286764],
                 mask=[False, False, False, False, False],
           fill_value=1e+20)


----------------------------------------------------------------------
Ran 23 tests in 149.556s

FAILED (failures=3)
Test failed: <unittest.runner.TextTestResult run=23 errors=0 failures=3>
error: Test failed: <unittest.runner.TextTestResult run=23 errors=0 failures=3>
```