### PR TITLE
Bugfix: Consistently checking sensor name in lower case

### DIFF
--- a/pyspectral/rsr_reader.py
+++ b/pyspectral/rsr_reader.py
@@ -113,12 +113,12 @@ class RelativeSpectralResponse(object):
     def _check_instrument(self):
         """Check and try fix instrument name if needed"""
         instr = INSTRUMENTS.get(self.platform_name, self.instrument.lower())
-        if instr != self.instrument:
+        if instr != self.instrument.lower():
             self.instrument = instr
             LOG.warning("Inconsistent instrument/satellite input - " +
                         "instrument set to %s", self.instrument)
 
-        self.instrument = self.instrument.replace('/', '')
+        self.instrument = self.instrument.lower().replace('/', '')
 
     def _get_filename(self):
         """Get the rsr filname from platform and instrument names, and download if not


### PR DESCRIPTION
Signed-off-by: Adam.Dybbroe <adam.dybbroe@smhi.se>

The instrument name checking was previously inconsistent so if an instrument name not internally registered in PySpetral was passed in upper case it gave a warning for inconsistent instrument-satellite naming. This should now be solved.

 - [x] Tests passed
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff``

