### PR TITLE
Interface fix: If wavelength in float is provided, assume it is an "e…

### DIFF
--- a/pyspectral/rayleigh.py
+++ b/pyspectral/rayleigh.py
@@ -176,11 +176,17 @@ class Rayleigh(object):
         return self._rayl, self._wvl_coord, self._azid_coord,\
             self._satz_sec_coord, self._sunz_sec_coord
 
-    def get_reflectance(self, sun_zenith, sat_zenith, azidiff, bandname,
-                        redband=None):
-        """Get the reflectance from the three sun-sat angles."""
+    def get_reflectance(self, sun_zenith, sat_zenith, azidiff, bandname, redband=None):
+        """Get the reflectance from the three sun-sat angles"""
         # Get wavelength in nm for band:
-        wvl = self.get_effective_wavelength(bandname) * 1000.0
+        if isinstance(bandname, float):
+            LOG.warning('A wavelength is provided instead of band name - ' +
+                        'disregard the relative spectral responses and assume ' +
+                        'it is the effective wavelength: %f (micro meter)', bandname)
+            wvl = bandname * 1000.0
+        else:
+            wvl = self.get_effective_wavelength(bandname) * 1000.0
+
         rayl, wvl_coord, azid_coord, satz_sec_coord, sunz_sec_coord = \
             self.get_reflectance_lut()
 


### PR DESCRIPTION
…ffective wavelength"

Signed-off-by: Adam.Dybbroe <adam.dybbroe@smhi.se>

When the get_reflectance method is called to perform atm correction, it will assume that the wavelength if provided as a float already is supposed to be the (rayleigh correction weighted) effective wavelength. Thus no calculation of the effective wavelength by reading the spectral response data will be done!

Thus, in the case that a new satellite not yet supported with the spectral responses in PySpectral, a download will not be attempted when providing a wavelength in float to the method. If a ban name is provided a download will be attempted, as the code is currently. To avoid trying to download RSR data in vain (cases where even after download the rsr data for the requested sensor and platform will anyway not be there) we need to check if the downloaded RSR data are the latest, so copy how we do for the atm correction LUTs. An issue about this will be raised!

 - [x] Tests passed 
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` 

