### PR TITLE
Change rayleigh correction to only compute things when needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,6 @@ matrix:
 install:
     - git clone --depth 1 git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
-    # See https://github.com/conda/conda/issues/7626#issuecomment-412922028
-    - conda config --remove channels defaults
-    - conda install -y $CONDA_DEPENDENCIES
 script: coverage run --source=pyspectral setup.py test
 after_success:
 - if [[ $PYTHON_VERSION == 3.6 ]]; then coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,15 @@ env:
   global:
   # Set defaults to avoid repeating in most cases
   - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
-  #- NUMPY_VERSION=stable
+  - NUMPY_VERSION=stable
   - MAIN_CMD='python setup.py'
-  - CONDA_DEPENDENCIES='scipy numpy coveralls coverage h5py mock requests six appdirs python-geotiepoints dask docutils pyyaml xlrd'
+  - CONDA_DEPENDENCIES='scipy coveralls coverage h5py mock requests six appdirs python-geotiepoints dask docutils pyyaml xlrd'
   - PIP_DEPENDENCIES=''
   - SETUP_XVFB=False
   - EVENT_TYPE='push pull_request cron'
   - SETUP_CMD='test'
   - CONDA_CHANNELS='conda-forge'
+  - CONDA_CHANNEL_PRIORITY='True'
 matrix:
   include:
     - env: PYTHON_VERSION=2.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,10 @@ environment:
     PYTHON: "C:\\conda"
     MINICONDA_VERSION: "latest"
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
-    CONDA_DEPENDENCIES: "scipy numpy coveralls coverage h5py mock requests six appdirs python-geotiepoints dask docutils pyaml xlrd"
+    CONDA_DEPENDENCIES: "scipy coveralls coverage h5py mock requests six appdirs python-geotiepoints dask docutils pyaml xlrd"
     PIP_DEPENDENCIES: ""
     CONDA_CHANNELS: "conda-forge"
+    CONDA_CHANNEL_PRIORITY: "True"
 
   matrix:
     - PYTHON: "C:\\Python27_64"

--- a/pyspectral/rayleigh.py
+++ b/pyspectral/rayleigh.py
@@ -263,14 +263,14 @@ class Rayleigh(object):
         smax = [sunz_sec_coord[-1], azid_coord[-1], satz_sec_coord[-1]]
         orders = [
             len(sunz_sec_coord), len(azid_coord), len(satz_sec_coord)]
+        f_3d_grid = atleast_2d(raylwvl.ravel())
 
-        if HAVE_DASK and isinstance(smin, Array):
+        if HAVE_DASK and isinstance(smin[0], Array):
             # compute all of these at the same time before passing to the interpolator
-            smin, smax, orders = da.compute(smin, smax, orders)
+            # otherwise they are computed separately
+            smin, smax, orders, f_3d_grid = da.compute(smin, smax, orders, f_3d_grid)
         minterp = MultilinearInterpolator(smin, smax, orders)
-
-        f_3d_grid = raylwvl
-        minterp.set_values(atleast_2d(f_3d_grid.ravel()))
+        minterp.set_values(f_3d_grid)
 
         def _do_interp(minterp, sunzsec, azidiff, satzsec):
             interp_points2 = np.vstack((sunzsec.ravel(),

--- a/pyspectral/rayleigh.py
+++ b/pyspectral/rayleigh.py
@@ -37,6 +37,7 @@ import numpy as np
 try:
     from dask.array import (where, zeros, clip, rad2deg, deg2rad, cos, arccos,
                             atleast_2d, Array, map_blocks, from_array)
+    import dask.array as da
     HAVE_DASK = True
     try:
         # use serializable h5py wrapper to make sure files are closed properly
@@ -45,6 +46,7 @@ try:
         pass
 except ImportError:
     from numpy import where, zeros, clip, rad2deg, deg2rad, cos, arccos, atleast_2d
+    da = None
     map_blocks = None
     from_array = None
     Array = None
@@ -261,6 +263,10 @@ class Rayleigh(object):
         smax = [sunz_sec_coord[-1], azid_coord[-1], satz_sec_coord[-1]]
         orders = [
             len(sunz_sec_coord), len(azid_coord), len(satz_sec_coord)]
+
+        if HAVE_DASK and isinstance(smin, Array):
+            # compute all of these at the same time before passing to the interpolator
+            smin, smax, orders = da.compute(smin, smax, orders)
         minterp = MultilinearInterpolator(smin, smax, orders)
 
         f_3d_grid = raylwvl
@@ -310,8 +316,7 @@ def get_reflectance_lut(filename):
 
     if HAVE_DASK:
         tab = from_array(tab, chunks=(10, 10, 10, 10))
-        # wvl_coord is used in a lot of non-dask functions, keep in memory
-        wvl = from_array(wvl, chunks=(100,)).persist()
+        wvl = wvl[:]  # no benefit to dask-ifying this
         azidiff = from_array(azidiff, chunks=(1000,))
         satellite_zenith_secant = from_array(satellite_zenith_secant,
                                              chunks=(1000,))
@@ -327,13 +332,3 @@ def get_reflectance_lut(filename):
         h5f.close()
 
     return tab, wvl, azidiff, satellite_zenith_secant, sun_zenith_secant
-
-
-# if __name__ == "__main__":
-#     SHAPE = (1000, 3000)
-#     NDIM = SHAPE[0] * SHAPE[1]
-#     SUNZ = np.ma.arange(
-#         NDIM / 2, NDIM + NDIM / 2).reshape(SHAPE) * 60. / float(NDIM)
-#     SATZ = np.ma.arange(NDIM).reshape(SHAPE) * 60. / float(NDIM)
-#     AZIDIFF = np.ma.arange(NDIM).reshape(SHAPE) * 179.9 / float(NDIM)
-#     rfl = this.get_reflectance(SUNZ, SATZ, AZIDIFF, 'M4')

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,6 @@ release=1
 
 [bdist_wheel]
 universal=1
+
+[flake8]
+max-line-length = 120


### PR DESCRIPTION
Along with other PRs I've been making on pyresample and satpy, this PR tweaks how dask is used so that things are only computed once and only when needed. This also reduces the amount of dask ProgressBars that may show up if someone is using the ProgressBar context manager. Overall, dask computes things less. Specifically, wavelengths are loaded as a normal numpy array and `smin`, `smax` and other variables are computed together before passing to the dask-unfriendly interpolator object.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
