### PR TITLE
Fix readthedocs

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -43,10 +43,10 @@ Near-Infrared reflectance
 Rayleigh scattering
 -------------------
 
-.. automodule:: pyspectral.rayleigh
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   .. automodule:: pyspectral.rayleigh
+       :members:
+       :undoc-members:
+       :show-inheritance:
 
 
 Utils

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,17 +20,21 @@ import os
 sys.path.insert(0, os.path.abspath('../'))
 sys.path.insert(0, os.path.abspath('../pyspectral'))
 
-# this is quite dirty approach but we're not working at NASA and nobody can die
-# because of that. Am I right?
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if on_rtd:
-    render_examples = False
-    # hack for lacking git-lfs support on rtd
-    from git_lfs import fetch
-    fetch(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
-else:
-    render_examples = True
+# PYTHONPATH = docs/source
+DOC_SOURCES_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_ROOT_DIR = os.path.dirname(os.path.dirname(DOC_SOURCES_DIR))
+sys.path.insert(0, DOC_SOURCES_DIR)
+print('PROJECT_ROOT_DIR', PROJECT_ROOT_DIR)
+
+# If runs on ReadTheDocs environment
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
+# Hack for lacking git-lfs support ReadTheDocs
+if on_rtd:
+    print('Fetching files with git_lfs')
+    from git_lfs import fetch
+    fetch(PROJECT_ROOT_DIR)
 
 
 class Mock(object):

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,18 +14,13 @@
 import sys
 import os
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('../'))
-sys.path.insert(0, os.path.abspath('../pyspectral'))
-
-
 # PYTHONPATH = docs/source
 DOC_SOURCES_DIR = os.path.dirname(os.path.abspath(__file__))
-PROJECT_ROOT_DIR = os.path.dirname(os.path.dirname(DOC_SOURCES_DIR))
+PROJECT_ROOT_DIR = os.path.dirname(DOC_SOURCES_DIR)
 sys.path.insert(0, DOC_SOURCES_DIR)
 print('PROJECT_ROOT_DIR', PROJECT_ROOT_DIR)
+from glob import glob
+print(glob(os.path.join(PROJECT_ROOT_DIR, '*')))
 
 # If runs on ReadTheDocs environment
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
@@ -35,6 +30,12 @@ if on_rtd:
     print('Fetching files with git_lfs')
     from git_lfs import fetch
     fetch(PROJECT_ROOT_DIR)
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+sys.path.insert(0, os.path.abspath('../'))
+sys.path.insert(0, os.path.abspath('../pyspectral'))
 
 
 class Mock(object):

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,6 +20,18 @@ import os
 sys.path.insert(0, os.path.abspath('../'))
 sys.path.insert(0, os.path.abspath('../pyspectral'))
 
+# this is quite dirty approach but we're not working at NASA and nobody can die
+# because of that. Am I right?
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+if on_rtd:
+    render_examples = False
+    # hack for lacking git-lfs support on rtd
+    from git_lfs import fetch
+    fetch(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+else:
+    render_examples = True
+
 
 class Mock(object):
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -63,9 +63,11 @@ class Mock(object):
 
 MOCK_MODULES = ['numpy', 'numpy.core',
                 'numpy.distutils.core', 'numpy.core.multiarray',
+                'dask',
                 'scipy', 'scipy.integrate', 'scipy.interpolate',
                 'scipy.interpolate.InterpolatedUnivariateSpline',
-                'geotiepoints', 'trollsift', 'trollsift.parser',
+                'geotiepoints', 'geotiepoints.multilinear',
+                'trollsift', 'trollsift.parser',
                 'h5py', 'tqdm', 'xlrd']
 
 for mod_name in MOCK_MODULES:
@@ -88,7 +90,7 @@ sys.path.insert(0, os.path.abspath('../pyspectral'))
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest',
               'sphinx.ext.todo', 'sphinx.ext.coverage',
               'sphinx.ext.intersphinx', 'sphinx.ext.napoleon',
-              'sphinx.ext.pngmath']
+              'sphinx.ext.imgmath']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,16 +18,13 @@ import os
 DOC_SOURCES_DIR = os.path.dirname(os.path.abspath(__file__))
 PROJECT_ROOT_DIR = os.path.dirname(DOC_SOURCES_DIR)
 sys.path.insert(0, DOC_SOURCES_DIR)
-print('PROJECT_ROOT_DIR', PROJECT_ROOT_DIR)
-from glob import glob
-print(glob(os.path.join(PROJECT_ROOT_DIR, '*')))
 
 # If runs on ReadTheDocs environment
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 # Hack for lacking git-lfs support ReadTheDocs
 if on_rtd:
-    print('Fetching files with git_lfs')
+    # print('Fetching files with git_lfs')
     from git_lfs import fetch
     fetch(PROJECT_ROOT_DIR)
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -53,6 +53,7 @@ color imagery.
    rsr_formatting
    api
 
+
 Indices and tables
 ==================
 

--- a/doc/rsr_formatting.rst
+++ b/doc/rsr_formatting.rst
@@ -1,0 +1,8 @@
+Formatting the original spectral responses
+------------------------------------------
+
+Pyspectral defines a unified hdf5 format to hold the various sensor specific
+relative spectral response functions.
+
+
+.. include:: ../rsr_convert_scripts/README.rst

--- a/doc/rtd_requirements.txt
+++ b/doc/rtd_requirements.txt
@@ -7,3 +7,4 @@ requests
 tqdm
 pyyaml
 xlrd
+git-lfs

--- a/pyspectral/rayleigh.py
+++ b/pyspectral/rayleigh.py
@@ -25,7 +25,6 @@
 to 800 nm
 
 """
-
 import os
 import time
 import logging
@@ -39,11 +38,11 @@ try:
                             atleast_2d, Array, map_blocks, from_array)
     import dask.array as da
     HAVE_DASK = True
-    try:
-        # use serializable h5py wrapper to make sure files are closed properly
-        import h5pickle as h5py
-    except ImportError:
-        pass
+    # try:
+    #     # use serializable h5py wrapper to make sure files are closed properly
+    #     import h5pickle as h5py
+    # except ImportError:
+    #     pass
 except ImportError:
     from numpy import where, zeros, clip, rad2deg, deg2rad, cos, arccos, atleast_2d
     da = None

--- a/rsr_convert_scripts/README.rst
+++ b/rsr_convert_scripts/README.rst
@@ -130,7 +130,7 @@ from ESA comes as a set of netCDF files. One file per band. Band 1:
 
    %> python viirs_rsr.py
 
-Converting the NOAA-20 Suomi-NPP VIIRS original responses to hdf5. File names
+Converting the NOAA-20 and Suomi-NPP VIIRS original responses to hdf5. File names
 follow 9 different naming conventions depending on the band, here as given in
 the pyspectral.yaml file:
 
@@ -174,4 +174,5 @@ the pyspectral.yaml file:
 
 
 Adam Dybbroe
-Thu Nov 29 15:23:30 2018
+Sat Dec  1 17:39:48 2018
+

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ except IOError:
 requires = ['docutils>=0.3', 'numpy>=1.5.1', 'scipy>=0.14',
             'python-geotiepoints>=1.1.1',
             'h5py>=2.5', 'requests', 'six', 'pyyaml',
-            'appdirs', 'git-lfs']
+            'appdirs']
 
 dask_extra = ['dask[array]']
 test_requires = ['pyyaml', 'dask[array]', 'xlrd']  # , 'matplotlib']

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ except IOError:
 requires = ['docutils>=0.3', 'numpy>=1.5.1', 'scipy>=0.14',
             'python-geotiepoints>=1.1.1',
             'h5py>=2.5', 'requests', 'six', 'pyyaml',
-            'appdirs']
+            'appdirs', 'git-lfs']
 
 dask_extra = ['dask[array]']
 test_requires = ['pyyaml', 'dask[array]', 'xlrd']  # , 'matplotlib']


### PR DESCRIPTION
Fixing the ReadTheDoc pages. RTD doesn't support git-lfs, and we added some png's recently in git-lfs.

 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->

