### PR TITLE
Feaure metimage multiple detectors

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -18,7 +18,7 @@ Now, you can work with the data as you wish, make some simple plot for instance:
   >>> [str(b) for b in olci.band_names]
   ['Oa01', 'Oa02', 'Oa03', 'Oa04', 'Oa05', 'Oa06', 'Oa07', 'Oa08', 'Oa09', 'Oa10', 'Oa11', 'Oa12', 'Oa13', 'Oa14', 'Oa15', 'Oa16', 'Oa17', 'Oa18', 'Oa19', 'Oa20', 'Oa21']
   >>> print("Central wavelength = {wvl:7.6f}".format(wvl=olci.rsr['Oa01']['det-1']['central_wavelength']))
-  Central wavelength = 0.400123
+  Central wavelength = 0.400303
   >>> import matplotlib.pyplot as plt
   >>> dummy = plt.figure(figsize=(10, 5))
   >>> import numpy as np

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -123,9 +123,10 @@ INSTRUMENTS = {'NOAA-19': 'avhrr/3',
                'Feng-Yun 3D': 'mersi-2'
                }
 
-HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/2617441/files/pyspectral_rsr_data.tgz"
+HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/2653487/files/pyspectral_rsr_data.tgz"
 RSR_DATA_VERSION_FILENAME = "PYSPECTRAL_RSR_VERSION"
-RSR_DATA_VERSION = "v1.0.5"
+RSR_DATA_VERSION = "v1.0.6"
+
 
 ATM_CORRECTION_LUT_VERSION = {}
 ATM_CORRECTION_LUT_VERSION['antarctic_aerosol'] = {'version': 'v1.0.1',

--- a/rsr_convert_scripts/metimage_rsr.py
+++ b/rsr_convert_scripts/metimage_rsr.py
@@ -28,7 +28,7 @@ derived from specifications I assume.
 
 import os
 import numpy as np
-from pyspectral.utils import convert2hdf5 as tohdf5
+from pyspectral.utils import get_central_wave
 from pyspectral.raw_reader import InstrumentRSR
 import logging
 
@@ -80,13 +80,84 @@ class MetImageRSR(InstrumentRSR):
         wavelength = 1. / data['wavenumber'] * 10000.
         response = data['response']
 
-        self.rsr = {'wavelength': wavelength, 'response': response}
+        # The real MetImage has 24 detectors. However, for now we store the
+        # single rsr as 'detector-1', indicating that there will be multiple
+        # detectors in the future:
+        detectors = {}
+        detectors['det-1'] = {'wavelength': wavelength, 'response': response}
+        self.rsr = detectors
+
+
+def generate_metimage_file(platform_name):
+    """Retrieve original RSR data and convert to internal hdf5 format.
+    """
+    import h5py
+
+    bandnames = METIMAGE_BAND_NAMES
+    instr = MetImageRSR(bandnames[0], platform_name)
+    instr_name = instr.instrument.replace('/', '')
+    filename = os.path.join(instr.output_dir,
+                            "rsr_{0}_{1}.h5".format(instr_name,
+                                                    platform_name))
+
+    with h5py.File(filename, "w") as h5f:
+        h5f.attrs['description'] = ('Relative Spectral Responses for ' +
+                                    instr.instrument.upper())
+        h5f.attrs['platform_name'] = platform_name
+        h5f.attrs['band_names'] = bandnames
+
+        for chname in bandnames:
+            metimage = MetImageRSR(chname, platform_name)
+            grp = h5f.create_group(chname)
+            grp.attrs['number_of_detectors'] = len(metimage.rsr.keys())
+            # Loop over each detector to check if the sampling wavelengths are
+            # identical:
+            det_names = list(metimage.rsr.keys())
+            wvl = metimage.rsr[det_names[0]]['wavelength']
+            wvl, idx = np.unique(wvl, return_index=True)
+            wvl_is_constant = True
+            for det in det_names[1:]:
+                det_wvl = np.unique(metimage.rsr[det]['wavelength'])
+                if not np.alltrue(wvl == det_wvl):
+                    LOG.warning(
+                        "Wavelngth arrays are not the same among detectors!")
+                    wvl_is_constant = False
+
+            if wvl_is_constant:
+                arr = wvl
+                dset = grp.create_dataset('wavelength', arr.shape, dtype='f')
+                dset.attrs['unit'] = 'm'
+                dset.attrs['scale'] = 1e-06
+                dset[...] = arr
+
+            # Loop over each detector:
+            for det in metimage.rsr:
+                det_grp = grp.create_group(det)
+                wvl = metimage.rsr[det]['wavelength'][
+                    ~np.isnan(metimage.rsr[det]['wavelength'])]
+                rsp = metimage.rsr[det]['response'][
+                    ~np.isnan(metimage.rsr[det]['wavelength'])]
+                wvl, idx = np.unique(wvl, return_index=True)
+                rsp = np.take(rsp, idx)
+                LOG.debug("wvl.shape: %s", str(wvl.shape))
+                det_grp.attrs[
+                    'central_wavelength'] = get_central_wave(wvl, rsp)
+                if not wvl_is_constant:
+                    arr = wvl
+                    dset = det_grp.create_dataset(
+                        'wavelength', arr.shape, dtype='f')
+                    dset.attrs['unit'] = 'm'
+                    dset.attrs['scale'] = 1e-06
+                    dset[...] = arr
+
+                dset = det_grp.create_dataset('response', rsp.shape, dtype='f')
+                dset[...] = rsp
 
 
 def main():
     """Main"""
     for platform_name in ["Metop-SG-A1", ]:
-        tohdf5(MetImageRSR, platform_name, METIMAGE_BAND_NAMES)
+        generate_metimage_file(platform_name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Restructure the MetImage rsr hdf5 file to follow the structure for multiple detectors. Eventhough there is only one detector at the moment

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
