### PR TITLE
Add support for olci on Sentinel-3B

### DIFF
--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -123,9 +123,9 @@ INSTRUMENTS = {'NOAA-19': 'avhrr/3',
                'Feng-Yun 3D': 'mersi-2'
                }
 
-HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/2617441/files/pyspectral_rsr_data.tgz"
+HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/2653487/files/pyspectral_rsr_data.tgz"
 RSR_DATA_VERSION_FILENAME = "PYSPECTRAL_RSR_VERSION"
-RSR_DATA_VERSION = "v1.0.5"
+RSR_DATA_VERSION = "v1.0.6"
 
 ATM_CORRECTION_LUT_VERSION = {}
 ATM_CORRECTION_LUT_VERSION['antarctic_aerosol'] = {'version': 'v1.0.1',

--- a/rsr_convert_scripts/olci_rsr.py
+++ b/rsr_convert_scripts/olci_rsr.py
@@ -37,7 +37,6 @@ import logging
 
 LOG = logging.getLogger(__name__)
 
-#RSRFILE = '/home/a000680/data/SpectralResponses/olci/OLCISRFNetCDF.nc4'
 RSRFILE = {'Sentinel-3A': '/home/a000680/data/SpectralResponses/olci/S3A_OL_SRF_20160713_mean_rsr.nc4',
            'Sentinel-3B': '/home/a000680/data/SpectralResponses/olciB/S3B_OL_SRF_0_20180109_mean_rsr.nc4'}
 

--- a/rsr_convert_scripts/olci_rsr.py
+++ b/rsr_convert_scripts/olci_rsr.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2016, 2017, 2018 Adam.Dybbroe
+# Copyright (c) 2016 - 2019 Adam.Dybbroe
 
 # Author(s):
 
@@ -23,7 +23,10 @@
 """
 Reading the Sentinel-3 OLCI relative spectral responses
 
-https://sentinel.esa.int/documents/247904/322304/OLCI+SRF+%28NetCDF%29/15cfd7a6-b7bc-4051-87f8-c35d765ae43a
+https://sentinel.esa.int/documents/247904/322304/OLCI+SRF+%28NetCDF%29/
+
+https://sentinel.esa.int/web/sentinel/technical-guides/sentinel-3-olci/olci-instrument/spectral-response-function-data
+
 """
 
 from netCDF4 import Dataset
@@ -34,7 +37,9 @@ import logging
 
 LOG = logging.getLogger(__name__)
 
-RSRFILE = '/home/a000680/data/SpectralResponses/olci/OLCISRFNetCDF.nc4'
+#RSRFILE = '/home/a000680/data/SpectralResponses/olci/OLCISRFNetCDF.nc4'
+RSRFILE = {'Sentinel-3A': '/home/a000680/data/SpectralResponses/olci/S3A_OL_SRF_20160713_mean_rsr.nc4',
+           'Sentinel-3B': '/home/a000680/data/SpectralResponses/olciB/S3B_OL_SRF_0_20180109_mean_rsr.nc4'}
 
 
 OLCI_BAND_NAMES = ['Oa01', 'Oa02', 'Oa03', 'Oa04',
@@ -73,18 +78,24 @@ class OlciRSR(InstrumentRSR):
         ncf = Dataset(self.path, 'r')
 
         bandnum = OLCI_BAND_NAMES.index(self.bandname)
-        cam = 0
-        view = 0
+        # cam = 0
+        # view = 0
+        # resp = ncf.variables[
+        #     'spectral_response_function'][bandnum, cam, view, :]
+        # wvl = ncf.variables[
+        #     'spectral_response_function_wavelength'][bandnum, cam, view, :] * scale
         resp = ncf.variables[
-            'spectral_response_function'][bandnum, cam, view, :]
+            'mean_spectral_response_function'][bandnum, :]
         wvl = ncf.variables[
-            'spectral_response_function_wavelength'][bandnum, cam, view, :] * scale
+            'mean_spectral_response_function_wavelength'][bandnum, :] * scale
+
         self.rsr = {'wavelength': wvl, 'response': resp}
 
 
 def main():
     """Main"""
-    for platform_name in ['Sentinel-3A', ]:
+    # for platform_name in ['Sentinel-3A', 'Sentinel-3B']:
+    for platform_name in ['Sentinel-3B', ]:
         tohdf5(OlciRSR, platform_name, OLCI_BAND_NAMES)
 
 
@@ -118,6 +129,7 @@ def testplot():
     ax.legend()
     fig.savefig('olci_band1.png')
     # pylab.show()
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->

Adding support for OLCI on Sentinel-3B and changing to use the mean spectral responses for both S3A and S3B!

Sentinel-3 OLCI has three levels of detail for the spectral responses (see the [ESA - Sentinel online](https://sentinel.esa.int/web/sentinel/technical-guides/sentinel-3-olci/olci-instrument/spectral-response-function-data):

-  The full dataset
    Includes for each of the 21 OLCI-A or B spectral bands, the centre wavelength, the bandwidth and the in-band solar irradiance at individual OLCI CCD columns (corresponding to the across track dimension of the instrument swath). This gives 5x21x740 spectral responses.
-  A subset of the dataset
    The same as the full file, but reduced to the spectral response functions at only three CCD columns (located at Eastern, centre, and Western part) for each module and each one of the 21 spectral bands. This gives 5x21x3 spectral responses
-  The mean dataset
    The same as the full file, but reduced to a single representative (mean) spectral response function, in-band solar irradiance, bandwidth and centre wavelength per band. This gives 21 spectral response functions.

And thus we use only the last one currently!

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
