### PR TITLE
Fix dask compatibility in blackbody functions

### DIFF
--- a/pyspectral/tests/test_blackbody.py
+++ b/pyspectral/tests/test_blackbody.py
@@ -43,18 +43,28 @@ WN_RAD_11MICRON_301KELVIN = 0.00117547716523
 __unittest = True
 
 
-class TestBlackbody(unittest.TestCase):
+class CustomScheduler(object):
+    """Custom dask scheduler that raises an exception if dask is computed too many times."""
 
+    def __init__(self, max_computes=1):
+        """Set starting and maximum compute counts."""
+        self.max_computes = max_computes
+        self.total_computes = 0
+
+    def __call__(self, dsk, keys, **kwargs):
+        """Compute dask task and keep track of number of times we do so."""
+        import dask
+        self.total_computes += 1
+        if self.total_computes > self.max_computes:
+            raise RuntimeError("Too many dask computations were scheduled: {}".format(self.total_computes))
+        return dask.get(dsk, keys, **kwargs)
+
+
+class TestBlackbody(unittest.TestCase):
     """Unit testing the blackbody function"""
 
-    def setUp(self):
-        """Set up"""
-        return
-
     def test_blackbody(self):
-        """Calculate the blackbody radiation from wavelengths and
-        temperatures
-        """
+        """Calculate the blackbody radiation from wavelengths and temperatures."""
         wavel = 11. * 1E-6
         black = blackbody((wavel, ), [300., 301])
         self.assertEqual(black.shape[0], 2)
@@ -71,14 +81,28 @@ class TestBlackbody(unittest.TestCase):
 
         tb_therm = np.array([[300., 301], [299, 298], [279, 286]])
         black = blackbody((10. * 1E-6, 11.e-6), tb_therm)
+        self.assertIsInstance(black, np.ndarray)
 
         tb_therm = np.array([[300., 301], [0., 298], [279, 286]])
         black = blackbody((10. * 1E-6, 11.e-6), tb_therm)
+        self.assertIsInstance(black, np.ndarray)
+
+    def test_blackbody_dask(self):
+        """Calculate the blackbody radiation from wavelengths and temperatures with dask arrays."""
+        import dask
+        import dask.array as da
+        tb_therm = da.from_array([[300., 301], [299, 298], [279, 286]], chunks=2)
+        with dask.config.set(scheduler=CustomScheduler(0)):
+            black = blackbody((10. * 1E-6, 11.e-6), tb_therm)
+        self.assertIsInstance(black, da.Array)
+
+        tb_therm = da.from_array([[300., 301], [0., 298], [279, 286]], chunks=2)
+        with dask.config.set(scheduler=CustomScheduler(0)):
+            black = blackbody((10. * 1E-6, 11.e-6), tb_therm)
+        self.assertIsInstance(black, da.Array)
 
     def test_blackbody_wn(self):
-        """Calculate the blackbody radiation from wavenumbers and
-        temperatures
-        """
+        """Calculate the blackbody radiation from wavenumbers and temperatures."""
         wavenumber = 90909.1  # 11 micron band
         black = blackbody_wn((wavenumber, ), [300., 301])
         self.assertEqual(black.shape[0], 2)
@@ -106,9 +130,24 @@ class TestBlackbody(unittest.TestCase):
 
         assertNumpyArraysEqual(t__, expected)
 
-    def tearDown(self):
-        """Clean up"""
-        return
+    def test_blackbody_wn_dask(self):
+        """Test that blackbody rad2temp preserves dask arrays."""
+        import dask
+        import dask.array as da
+        wavenumber = 90909.1  # 11 micron band
+        radiances = da.from_array([0.001, 0.0009, 0.0012, 0.0018], chunks=2).reshape(2, 2)
+        with dask.config.set(scheduler=CustomScheduler(0)):
+            t__ = blackbody_wn_rad2temp(wavenumber, radiances)
+        self.assertIsInstance(t__, da.Array)
+        t__ = t__.compute()
+        expected = np.array([290.3276916, 283.76115441,
+                             302.4181330, 333.1414164]).reshape(2, 2)
+        self.assertAlmostEqual(t__[1, 1], expected[1, 1], 5)
+        self.assertAlmostEqual(t__[0, 0], expected[0, 0], 5)
+        self.assertAlmostEqual(t__[0, 1], expected[0, 1], 5)
+        self.assertAlmostEqual(t__[1, 0], expected[1, 0], 5)
+
+        assertNumpyArraysEqual(t__, expected)
 
 
 def suite():


### PR DESCRIPTION
I was writing the MERSI-2 L1B reader and needed to use the rad2temp function. I noticed that when dask arrays were passed they were being converted to a numpy array. This PR fixes the usage with the least amount of changes possible.

The biggest difference is that in the `planck` function a masked array was being used with `-9` as the original sentinel value. As far as I could tell the masked array was being used for two reasons: to make `min/max` calls ignore the masked values and to later use the `.mask` to replace masked values with NaN. I switched this to use NaN right away instead of `-9` and to only print out min/max debug information when the input is an numpy array.

I'm marking this as a bug fix because although its a feature, it is more about fixing a working function so it returns what I want.

 - [x] Closes #73 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
