### PR TITLE
Feature download LUT files only if outdated

### DIFF
--- a/bin/download_atm_correction_luts.py
+++ b/bin/download_atm_correction_luts.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2018 Adam.Dybbroe
+# Copyright (c) 2018, 2019 Adam.Dybbroe
 
 # Author(s):
 
@@ -27,9 +27,11 @@ spectral range
 
 import logging
 import argparse
+from pyspectral.rayleigh import RayleighConfigBaseClass
 from pyspectral.utils import download_luts, AEROSOL_TYPES
 from pyspectral.utils import logging_on, logging_off
 
+LOG = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -51,7 +53,13 @@ if __name__ == "__main__":
     if verbose:
         logging_on(logging.DEBUG)
     else:
-        logging_off()
+        # logging_off()
+        logging_on(logging.INFO)
 
-    # Download:
-    download_luts(aerosol_type=aerosol_types, dry_run=dry_run)
+    for aerosol_type in aerosol_types:
+        atmcorr = RayleighConfigBaseClass(aerosol_type)
+        if atmcorr.lutfiles_version_uptodate:
+            LOG.info("Atm correction LUT files already the latest!")
+        else:
+            # Download
+            download_luts(aerosol_type=aerosol_type, dry_run=dry_run)

--- a/bin/download_atm_correction_luts.py
+++ b/bin/download_atm_correction_luts.py
@@ -27,9 +27,9 @@ spectral range
 
 import logging
 import argparse
-from pyspectral.rayleigh import RayleighConfigBaseClass
-from pyspectral.utils import download_luts, AEROSOL_TYPES
+from pyspectral.utils import AEROSOL_TYPES
 from pyspectral.utils import logging_on, logging_off
+from pyspectral.rayleigh import check_and_download
 
 LOG = logging.getLogger(__name__)
 
@@ -53,13 +53,6 @@ if __name__ == "__main__":
     if verbose:
         logging_on(logging.DEBUG)
     else:
-        # logging_off()
-        logging_on(logging.INFO)
+        logging_off()
 
-    for aerosol_type in aerosol_types:
-        atmcorr = RayleighConfigBaseClass(aerosol_type)
-        if atmcorr.lutfiles_version_uptodate:
-            LOG.info("Atm correction LUT files already the latest!")
-        else:
-            # Download
-            download_luts(aerosol_type=aerosol_type, dry_run=dry_run)
+    check_and_download(aerosol_type=aerosol_types, dry_run=dry_run)

--- a/bin/download_rsr.py
+++ b/bin/download_rsr.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2018 Adam.Dybbroe
+# Copyright (c) 2018, 2019 Adam.Dybbroe
 
 # Author(s):
 
@@ -28,6 +28,11 @@ import argparse
 from pyspectral.utils import download_rsr
 from pyspectral.utils import logging_on, logging_off
 
+from pyspectral.rsr_reader import RSRDataBaseClass
+
+LOG = logging.getLogger(__name__)
+
+
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
@@ -45,12 +50,18 @@ if __name__ == "__main__":
     verbose = args.verbose
     dry_run = args.dry_run
 
+    rsr = RSRDataBaseClass()
+
     if verbose:
         logging_on(logging.DEBUG)
     else:
-        logging_off()
+        # logging_off()
+        logging_on(logging.INFO)
 
-    if dest_dir:
-        download_rsr(dest_dir=dest_dir, dry_run=dry_run)
+    if rsr.rsr_data_version_uptodate:
+        LOG.info("RSR data already the latest!")
     else:
-        download_rsr(dry_run=dry_run)
+        if dest_dir:
+            download_rsr(dest_dir=dest_dir, dry_run=dry_run)
+        else:
+            download_rsr(dry_run=dry_run)

--- a/bin/download_rsr.py
+++ b/bin/download_rsr.py
@@ -25,10 +25,8 @@
 
 import logging
 import argparse
-from pyspectral.utils import download_rsr
 from pyspectral.utils import logging_on, logging_off
-
-from pyspectral.rsr_reader import RSRDataBaseClass
+from pyspectral.rsr_reader import check_and_download
 
 LOG = logging.getLogger(__name__)
 
@@ -50,18 +48,12 @@ if __name__ == "__main__":
     verbose = args.verbose
     dry_run = args.dry_run
 
-    rsr = RSRDataBaseClass()
-
     if verbose:
         logging_on(logging.DEBUG)
     else:
-        # logging_off()
-        logging_on(logging.INFO)
+        logging_off()
 
-    if rsr.rsr_data_version_uptodate:
-        LOG.info("RSR data already the latest!")
+    if dest_dir:
+        check_and_download(dest_dir=dest_dir, dry_run=dry_run)
     else:
-        if dest_dir:
-            download_rsr(dest_dir=dest_dir, dry_run=dry_run)
-        else:
-            download_rsr(dry_run=dry_run)
+        check_and_download(dry_run=dry_run)

--- a/pyspectral/rayleigh.py
+++ b/pyspectral/rayleigh.py
@@ -363,7 +363,8 @@ def check_and_download(**kwargs):
     for aerosol_type in aerosol_types:
         atmcorr = RayleighConfigBaseClass(aerosol_type)
         if atmcorr.lutfiles_version_uptodate:
-            LOG.info("Atm correction LUT files already the latest!")
+            LOG.info("Atm correction LUTs, for aerosol distribution %s, already the latest!",
+                     aerosol_type)
         else:
             # Download
             download_luts(aerosol_type=aerosol_type, dry_run=dry_run)

--- a/pyspectral/rayleigh.py
+++ b/pyspectral/rayleigh.py
@@ -349,3 +349,21 @@ def get_reflectance_lut(filename):
         h5f.close()
 
     return tab, wvl, azidiff, satellite_zenith_secant, sun_zenith_secant
+
+
+def check_and_download(**kwargs):
+    """Do a check for the version of the atmospheric correction LUTs and attempt
+       downloading only if needed
+
+    """
+
+    aerosol_types = kwargs.get('aerosol_types', AEROSOL_TYPES)
+    dry_run = kwargs.get('dry_run', False)
+
+    for aerosol_type in aerosol_types:
+        atmcorr = RayleighConfigBaseClass(aerosol_type)
+        if atmcorr.lutfiles_version_uptodate:
+            LOG.info("Atm correction LUT files already the latest!")
+        else:
+            # Download
+            download_luts(aerosol_type=aerosol_type, dry_run=dry_run)

--- a/pyspectral/rsr_reader.py
+++ b/pyspectral/rsr_reader.py
@@ -266,6 +266,19 @@ class RelativeSpectralResponse(RSRDataBaseClass):
             raise NotImplementedError(errmsg)
 
 
+def check_and_download(dest_dir=None):
+    """Do a check for the version and attempt downloading only if needed"""
+
+    rsr = RSRDataBaseClass()
+    if rsr.rsr_data_version_uptodate:
+        LOG.info("RSR data already the latest!")
+    else:
+        if dest_dir:
+            download_rsr(dest_dir=dest_dir)
+        else:
+            download_rsr()
+
+
 def main():
     """Main"""
     modis = RelativeSpectralResponse('EOS-Terra', 'modis')

--- a/pyspectral/rsr_reader.py
+++ b/pyspectral/rsr_reader.py
@@ -266,17 +266,20 @@ class RelativeSpectralResponse(RSRDataBaseClass):
             raise NotImplementedError(errmsg)
 
 
-def check_and_download(dest_dir=None):
+def check_and_download(**kwargs):
     """Do a check for the version and attempt downloading only if needed"""
+
+    dry_run = kwargs.get('dry_run', False)
+    dest_dir = kwargs.get('dest_dir', None)
 
     rsr = RSRDataBaseClass()
     if rsr.rsr_data_version_uptodate:
         LOG.info("RSR data already the latest!")
     else:
         if dest_dir:
-            download_rsr(dest_dir=dest_dir)
+            download_rsr(dest_dir=dest_dir, dry_run=dry_run)
         else:
-            download_rsr()
+            download_rsr(dry_run=dry_run)
 
 
 def main():

--- a/pyspectral/rsr_reader.py
+++ b/pyspectral/rsr_reader.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2014-2018 Adam.Dybbroe
+# Copyright (c) 2014-2019 Adam.Dybbroe
 
 # Author(s):
 
@@ -38,25 +38,11 @@ from pyspectral.utils import (INSTRUMENTS, download_rsr)
 from pyspectral.utils import (RSR_DATA_VERSION_FILENAME, RSR_DATA_VERSION)
 
 
-class RelativeSpectralResponse(object):
-    """Container for the relative spectral response functions for various
-    satellite imagers
-    """
+class RSRDataBaseClass(object):
 
-    def __init__(self, platform_name=None, instrument=None, **kwargs):
+    def __init__(self):
         """Create the instance either from platform name and instrument or from
         filename and load the data"""
-        self.platform_name = platform_name
-        self.instrument = instrument
-        self.filename = None
-        if not self.instrument or not self.platform_name:
-            if 'filename' in kwargs:
-                self.filename = kwargs['filename']
-            else:
-                raise AttributeError(
-                    "platform name and sensor or filename must be specified")
-        else:
-            self._check_instrument()
 
         self.rsr = {}
         self.description = "Unknown"
@@ -76,6 +62,48 @@ class RelativeSpectralResponse(object):
         if self._get_rsr_data_version() == RSR_DATA_VERSION:
             self._rsr_data_version_uptodate = True
 
+    def _get_rsr_data_version(self):
+        """Check the version of the RSR data from the version file in the RSR
+           directory
+
+        """
+
+        rsr_data_version_path = os.path.join(self.rsr_dir, RSR_DATA_VERSION_FILENAME)
+        if not os.path.exists(rsr_data_version_path):
+            return "v0.0.0"
+
+        with open(rsr_data_version_path, 'r') as fpt:
+            # Get the version from the file
+            return fpt.readline().strip()
+
+    @property
+    def rsr_data_version_uptodate(self):
+        return self._rsr_data_version_uptodate
+
+
+class RelativeSpectralResponse(RSRDataBaseClass):
+    """Container for the relative spectral response functions for various
+    satellite imagers
+    """
+
+    def __init__(self, platform_name=None, instrument=None, **kwargs):
+        """Create the instance either from platform name and instrument or from
+        filename and load the data"""
+
+        super(RelativeSpectralResponse, self).__init__()
+
+        self.platform_name = platform_name
+        self.instrument = instrument
+        self.filename = None
+        if not self.instrument or not self.platform_name:
+            if 'filename' in kwargs:
+                self.filename = kwargs['filename']
+            else:
+                raise AttributeError(
+                    "platform name and sensor or filename must be specified")
+        else:
+            self._check_instrument()
+
         if not self.filename:
             self._get_filename()
 
@@ -94,20 +122,6 @@ class RelativeSpectralResponse(object):
 
         LOG.debug('Filename: %s', str(self.filename))
         self.load()
-
-    def _get_rsr_data_version(self):
-        """Check the version of the RSR data from the version file in the RSR
-           directory
-
-        """
-
-        rsr_data_version_path = os.path.join(self.rsr_dir, RSR_DATA_VERSION_FILENAME)
-        if not os.path.exists(rsr_data_version_path):
-            return "v0.0.0"
-
-        with open(rsr_data_version_path, 'r') as fpt:
-            # Get the version from the file
-            return fpt.readline().strip()
 
     def _check_instrument(self):
         """Check and try fix instrument name if needed"""


### PR DESCRIPTION
The download scripts will first check if the LUT files (RSR data or atm correction LUTs) are up to date. Only if they are old, a download will be attempted

 - [x] Closes #75 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
