### PR TITLE
Fix rsr zenodo version

### DIFF
--- a/pyspectral/blackbody.py
+++ b/pyspectral/blackbody.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2013-2018 Adam.Dybbroe
+# Copyright (c) 2013-2019 Adam.Dybbroe
 
 # Author(s):
 
@@ -121,7 +121,7 @@ def blackbody_wn_rad2temp(wavenumber, radiance):
 
 
 def planck(wave, temperature, wavelength=True):
-    """The Planck radiation or Blackbody radiation as a function of wavelength 
+    """The Planck radiation or Blackbody radiation as a function of wavelength
     or wavenumber. SI units.
     _planck(wave, temperature, wavelength=True)
     wave = Wavelength/wavenumber or a sequence of wavelengths/wavenumbers (m or m^-1)

--- a/pyspectral/rsr_reader.py
+++ b/pyspectral/rsr_reader.py
@@ -27,15 +27,14 @@ import os
 import numpy as np
 from glob import glob
 from os.path import expanduser
-
-import logging
-LOG = logging.getLogger(__name__)
-
 from pyspectral.config import get_config
 from pyspectral.utils import WAVE_NUMBER
 from pyspectral.utils import WAVE_LENGTH
 from pyspectral.utils import (INSTRUMENTS, download_rsr)
 from pyspectral.utils import (RSR_DATA_VERSION_FILENAME, RSR_DATA_VERSION)
+
+import logging
+LOG = logging.getLogger(__name__)
 
 
 class RSRDataBaseClass(object):

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -125,8 +125,7 @@ INSTRUMENTS = {'NOAA-19': 'avhrr/3',
                }
 
 
-HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/3358843/files/pyspectral_rsr_data.tgz"
-    "https://zenodo.org/record/3381083/files/pyspectral_rsr_data.tgz"
+HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/3381083/files/pyspectral_rsr_data.tgz"
 RSR_DATA_VERSION_FILENAME = "PYSPECTRAL_RSR_VERSION"
 RSR_DATA_VERSION = "v1.0.8"
 

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -120,12 +120,15 @@ INSTRUMENTS = {'NOAA-19': 'avhrr/3',
                'Suomi-NPP': 'viirs',
                'NOAA-20': 'viirs',
                'FY-3D': 'mersi-2',
-               'Feng-Yun 3D': 'mersi-2'
+               'Feng-Yun 3D': 'mersi-2',
+               'FY-4A': 'agri'
                }
 
-HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/2653487/files/pyspectral_rsr_data.tgz"
+
+HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/3358843/files/pyspectral_rsr_data.tgz"
+    "https://zenodo.org/record/3381083/files/pyspectral_rsr_data.tgz"
 RSR_DATA_VERSION_FILENAME = "PYSPECTRAL_RSR_VERSION"
-RSR_DATA_VERSION = "v1.0.7"
+RSR_DATA_VERSION = "v1.0.8"
 
 ATM_CORRECTION_LUT_VERSION = {}
 ATM_CORRECTION_LUT_VERSION['antarctic_aerosol'] = {'version': 'v1.0.1',


### PR DESCRIPTION
The zenodo version was newer than the one pointed to by the code.
Also the latest FY-4A AGRI rsr data had not been included as intended.

This PR fixes these two issues.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
