### PR TITLE
Fix doc tests for python 2&3

### DIFF
--- a/doc/37_reflectance.rst
+++ b/doc/37_reflectance.rst
@@ -46,7 +46,7 @@ expressed in :math:`W/m^2 sr^{-1} \mu m^{-1}`, or using SI units :math:`W/m^2 sr
   >>> viirs = RadTbConverter('Suomi-NPP', 'viirs', 'M12')
   >>> rad37 = viirs.tb2radiance(tb37)
   >>> print([np.round(rad, 7) for rad in rad37['radiance']])
-  [369717.4765726, 355110.5207853, 314684.2788726, 173143.5424898, 116408.0007877]
+  [369717.4972296, 355110.6414922, 314684.3507084, 173143.4836477, 116408.0022674]
   >>> rad37['unit']
   'W/m^2 sr^-1 m^-1'
 
@@ -59,7 +59,7 @@ In order to get the total radiance over the band one has to multiply with the eq
   >>> viirs = RadTbConverter('Suomi-NPP', 'viirs', 'M12')
   >>> rad37 = viirs.tb2radiance(tb37, normalized=False)
   >>> print([np.round(rad, 8) for rad in rad37['radiance']])
-  [0.07037968, 0.06759909, 0.05990352, 0.03295972, 0.02215951]
+  [0.07037968, 0.06759911, 0.05990353, 0.03295971, 0.02215951]
   >>> rad37['unit']
   'W/m^2 sr^-1'
 
@@ -218,17 +218,17 @@ We can try decompose equation :eq:`refl37` above using the example of VIIRS M12 
   >>> print(np.isnan(nomin))
   [False False False False False]
   >>> print([np.round(val, 8) for val in nomin])
-  [0.05083677, 0.04805618, 0.0404157, 0.01279279, 0.00204485]
+  [0.05083677, 0.0480562, 0.04041571, 0.01279277, 0.00204485]
   >>> denom = np.cos(np.deg2rad(sunz))/np.pi * sflux - rad11['radiance']
   >>> print(np.isnan(denom))
   [False False False False False]
   >>> print([np.round(val, 8) for val in denom])
-  [0.23646313, 0.23645682, 0.23650559, 0.23582015, 0.2358661]
+  [0.23646312, 0.23645681, 0.23650559, 0.23582014, 0.23586609]
   >>> res = nomin/denom
   >>> print(np.isnan(res))
   [False False False False False]
   >>> print([np.round(val, 8) for val in res])
-  [0.21498817, 0.2032345, 0.17088689, 0.05424807, 0.00866955]
+  [0.21498817, 0.20323458, 0.17088693, 0.05424801, 0.00866952]
 
 
 Derive the emissive part of the 3.7 micron band
@@ -255,5 +255,5 @@ Using the example of the VIIRS M12 band from above this gives the following spec
   >>> ['{tb:6.3f}'.format(tb=np.round(t, 4)) for t in tb]
   ['266.996', '267.262', '267.991', '271.033', '271.927']
   >>> rad = refl_m12.emissive_part_3x(tb=False)
-  >>> ['{rad:6.3f}'.format(rad=np.round(r, 3)) for r in rad]
-  ['80285.149', '81458.022', '84749.639', '99761.400', '104582.030']
+  >>> ['{rad:6.3f}'.format(rad=np.round(r, 3)) for r in rad.compute()]
+  ['80285.150', '81458.022', '84749.638', '99761.401', '104582.031']

--- a/doc/rad_definitions.rst
+++ b/doc/rad_definitions.rst
@@ -229,7 +229,7 @@ And using wavelength representation:
    >>> wvl = 1./wavenumber
    >>> rad = blackbody(wvl, [300., 301])
    >>> print("{0:10.3f} {1:10.3f}".format(rad[0], rad[1]))
-   9573178.886 9714689.259
+   9573177.494 9714687.157
 
 Which are the spectral radiances in SI units around :math:`11 \mu m` at
 temperatures 300 and 301 Kelvin. In units of :math:`mW/m^2\ m^{-1} sr^{-1}` this becomes:

--- a/pyspectral/blackbody.py
+++ b/pyspectral/blackbody.py
@@ -175,7 +175,7 @@ def planck(wave, temperature, wavelength=True):
                   str(np.nanmax(arg2)), str(np.nanmin(arg2)))
 
     try:
-        exp_arg = np.multiply(arg1.astype('float32'), arg2.astype('float32'))
+        exp_arg = np.multiply(arg1.astype('float64'), arg2.astype('float64'))
     except MemoryError:
         LOG.warning(("Dimensions used in numpy.multiply probably reached "
                      "limit!\n"

--- a/pyspectral/tests/test_atm_correction_ir.py
+++ b/pyspectral/tests/test_atm_correction_ir.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2017 Adam.Dybbroe
+# Copyright (c) 2017 - 2019 Pytroll
 
 # Author(s):
 
-#   Adam.Dybbroe <a000680@c20671.ad.smhi.se>
+#   Adam.Dybbroe <adam.dybbroe@smhi.se>
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,14 +22,13 @@
 """Unit tests of the atmospherical correction in the ir spectral range."""
 
 
+import numpy as np
+from pyspectral.atm_correction_ir import AtmosphericalCorrection
 import sys
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
     import unittest
-
-import numpy as np
-from pyspectral.atm_correction_ir import AtmosphericalCorrection
 
 SATZ = np.ma.array([[48.03,  48.03002,  48.03004,  48.03006,  48.03008,  48.0301,
                      48.03012,  48.03014,  48.03016,  48.03018],

--- a/pyspectral/tests/test_blackbody.py
+++ b/pyspectral/tests/test_blackbody.py
@@ -31,9 +31,7 @@ from pyspectral.tests.unittest_helpers import assertNumpyArraysEqual
 import unittest
 import numpy as np
 
-#RAD_11MICRON_300KELVIN = 9573177.8811719529
 RAD_11MICRON_300KELVIN = 9573176.935507433
-#RAD_11MICRON_301KELVIN = 9714688.2959563732
 RAD_11MICRON_301KELVIN = 9714686.576498277
 
 # Radiances in wavenumber space (SI-units)

--- a/pyspectral/tests/test_blackbody.py
+++ b/pyspectral/tests/test_blackbody.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2013, 2014, 2015, 2016, 2017 Adam.Dybbroe
+# Copyright (c) 2013 - 2019 Pytroll
 
 # Author(s):
 
-#   Adam.Dybbroe <a000680@c14526.ad.smhi.se>
+#   Adam.Dybbroe <adam.dybbroe@smhi.se>
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -31,10 +31,10 @@ from pyspectral.tests.unittest_helpers import assertNumpyArraysEqual
 import unittest
 import numpy as np
 
-#RAD_11MICRON_300KELVIN = 9572498.1141643394
-RAD_11MICRON_300KELVIN = 9573177.8811719529
-#RAD_11MICRON_301KELVIN = 9713997.9623772576
-RAD_11MICRON_301KELVIN = 9714688.2959563732
+#RAD_11MICRON_300KELVIN = 9573177.8811719529
+RAD_11MICRON_300KELVIN = 9573176.935507433
+#RAD_11MICRON_301KELVIN = 9714688.2959563732
+RAD_11MICRON_301KELVIN = 9714686.576498277
 
 # Radiances in wavenumber space (SI-units)
 WN_RAD_11MICRON_300KELVIN = 0.00115835441353

--- a/pyspectral/tests/test_rad_tb_conversions.py
+++ b/pyspectral/tests/test_rad_tb_conversions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2014-2018 Adam.Dybbroe
+# Copyright (c) 2014-2019 Adam.Dybbroe
 
 # Author(s):
 
@@ -347,10 +347,10 @@ class TestRadTbConversions(unittest.TestCase):
         self.assertTrue(np.allclose(TRUE_RADS * integral, res['radiance']))
 
         res = self.modis.tb2radiance(237., lut=False)
-        self.assertAlmostEqual(16570.592171157, res['radiance'])
+        self.assertAlmostEqual(16570.579551068, res['radiance'])
 
         res = self.modis.tb2radiance(277., lut=False)
-        self.assertAlmostEqual(167544.3823631, res['radiance'])
+        self.assertAlmostEqual(167544.39368663222, res['radiance'])
 
         res = self.modis.tb2radiance(1.1, lut=False)
         self.assertAlmostEqual(0.0, res['radiance'])
@@ -362,7 +362,7 @@ class TestRadTbConversions(unittest.TestCase):
         self.assertAlmostEqual(5.3940515573e-06, res['radiance'])
 
         res = self.modis.tb2radiance(200.1, lut=False)
-        self.assertAlmostEqual(865.09776189, res['radiance'])
+        self.assertAlmostEqual(865.09759706, res['radiance'])
 
     def tearDown(self):
         """Clean up"""


### PR DESCRIPTION
Use float64 consistently in blackbody calculations and fix doc tests and unittests accordingly for both python-2 and python-3

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
