### PR TITLE
Fix for appveyor, using Daves custom branch&fork of ci-helpers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+exclude: '^$'
+fail_fast: false
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.2.3
+    hooks:
+    - id: flake8
+      additional_dependencies: [flake8-docstrings, flake8-debugger, flake8-bugbear]

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ env:
   - EVENT_TYPE='push pull_request cron'
   - SETUP_CMD='test'
   - CONDA_CHANNELS='conda-forge'
-  - CONDA_CHANNEL_PRIORITY='True'
+  - CONDA_CHANNEL_PRIORITY="strict"
+
 matrix:
   include:
     - env: PYTHON_VERSION=2.7
@@ -25,7 +26,8 @@ matrix:
       os: osx
       language: generic
 install:
-    - git clone --depth 1 git://github.com/astropy/ci-helpers.git
+#    - git clone --depth 1 git://github.com/astropy/ci-helpers.git
+    - git clone --depth 1 -b all-the-fixes git://github.com/djhoese/ci-helpers.git    
     - source ci-helpers/travis/setup_conda.sh
 script: coverage run --source=pyspectral setup.py test
 after_success:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,10 +20,10 @@ environment:
       NUMPY_VERSION: "stable"
 
 install:
-    - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
+#    - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
+    - "git clone --depth 1 -b all-the-fixes git://github.com/djhoese/ci-helpers.git"
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
-    - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-    - "activate test"
+    - "conda activate test"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 


### PR DESCRIPTION
Signed-off-by: Adam Dybbroe <Adam.Dybbroe@smhi.se>

Fix automatic tests for Appveyor using Daves custom fork and branch of ci-helpers

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
