### PR TITLE
Adapt for later versions of TQDM

### DIFF
--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -433,7 +433,7 @@ def download_luts(**kwargs):
     else:
         aerosol_types = HTTPS_RAYLEIGH_LUTS.keys()
 
-    chunk_size = 4096
+    chunk_size = 1024*1024  # 1 MB
 
     for subname in aerosol_types:
 

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -433,7 +433,7 @@ def download_luts(**kwargs):
     else:
         aerosol_types = HTTPS_RAYLEIGH_LUTS.keys()
 
-    chunk_size = 10124
+    chunk_size = 4096
 
     for subname in aerosol_types:
 
@@ -461,7 +461,7 @@ def download_luts(**kwargs):
         if TQDM_LOADED:
             with open(filename, "wb") as handle:
                 for data in tqdm(iterable=response.iter_content(chunk_size=chunk_size),
-                                 total=(total_size / chunk_size), unit='kB'):
+                                 total=(int(total_size / chunk_size + 0.5)), unit='kB'):
                     handle.write(data)
         else:
             with open(filename, "wb") as handle:


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
Adjust ftp download chunk size and the number of expected iterations to an integer.

In the most recent version of tqdm (4.40 as opposed to 4.37) pyspectral fails if the total number of iterations when downloading data in chunks is not an integer. 

tqdm is used to show status bar when downloading LUTs via ftp.

Thanks to @aronnem for reporting this!

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
