### PR TITLE
Fix Read The Doc pages - does not build at the moment

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -17,17 +17,8 @@ from pkg_resources import get_distribution
 
 # PYTHONPATH = docs/source
 DOC_SOURCES_DIR = os.path.dirname(os.path.abspath(__file__))
-PROJECT_ROOT_DIR = os.path.dirname(DOC_SOURCES_DIR)
 sys.path.insert(0, DOC_SOURCES_DIR)
 
-# If runs on ReadTheDocs environment
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-
-# Hack for lacking git-lfs support ReadTheDocs
-if on_rtd:
-    # print('Fetching files with git_lfs')
-    from git_lfs import fetch
-    fetch(PROJECT_ROOT_DIR)
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -39,7 +30,7 @@ sys.path.insert(0, os.path.abspath('../pyspectral'))
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-release = get_distribution('satpy').version
+release = get_distribution('pyspectral').version
 # for example take major/minor
 version = '.'.join(release.split('.')[:2])
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -27,7 +27,7 @@ The source code can be found on the github_ page.
 With PySpectral and SatPy_ (or previously mpop_) it is possible to make RGB colour
 composites like the SEVIRI `day solar`_ or the `day microphysical`_ RGB
 composites according to the `MSG Interpretation Guide`_ (EUMETSAT_). Also with
-SatPy_ (and mpop_) integration it is possible to make atmosphere corrected true
+SatPy_ integration it is possible to make atmosphere corrected true
 color imagery.
 
 .. _`EUMETSAT`: http://www.eumetsat.int/

--- a/doc/rayleigh_correction.rst
+++ b/doc/rayleigh_correction.rst
@@ -35,7 +35,7 @@ in the figure below:
    :scale: 70%
    :align: center
 
-The method is descriped in detail in a scientific paper_.
+The method is descriped in detail in a `scientific paper`_.
 
 To apply the atmospheric correction for a given satellite sensor band, the
 procedure involves the following three steps:
@@ -113,6 +113,6 @@ if you want another setup, e.g.:
 
 .. _Satpy: http://www.github.com/pytroll/satpy
 .. _zenodo: https://doi.org/10.5281/zenodo.1288441
-.. _paper: https://doi.org/10.3390/rs10040560
+.. _`scientific paper`: https://doi.org/10.3390/rs10040560
 
 


### PR DESCRIPTION
Fix cut'n'paste bug and remove git-lfs stuff as we do not use git-lfs anymore
Use python 3 to build RTD pages.

<!-- Describe what your PR does, and why -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
