### PR TITLE
Updated Zenodo link for addition of SLSTR on Sentinel 3B

### DIFF
--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -156,9 +156,9 @@ INSTRUMENTS = {'NOAA-19': 'avhrr/3',
                }
 
 
-HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/3461164/files/pyspectral_rsr_data.tgz"
+HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/3667766/files/pyspectral_rsr_data.tgz"
 RSR_DATA_VERSION_FILENAME = "PYSPECTRAL_RSR_VERSION"
-RSR_DATA_VERSION = "v1.0.10"
+RSR_DATA_VERSION = "v1.0.11"
 
 ATM_CORRECTION_LUT_VERSION = {}
 ATM_CORRECTION_LUT_VERSION['antarctic_aerosol'] = {'version': 'v1.0.1',

--- a/rsr_convert_scripts/slstr_rsr.py
+++ b/rsr_convert_scripts/slstr_rsr.py
@@ -23,7 +23,7 @@
 """
 Sentinel-3 SLSTR spectral response function interface
 
-https://sentinel.esa.int/documents/247904/322305/SLSTR_FM02_Spectral_Responses_Necdf_zip/3a4482b8-6e44-47f3-a8f2-79c000663976
+https://sentinel.esa.int/web/sentinel/technical-guides/sentinel-3-slstr/instrument/measured-spectral-response-function-data
 
 """
 
@@ -81,7 +81,7 @@ class SlstrRSR(InstrumentRSR):
 
 def main():
     """Main"""
-    for platform_name in ['Sentinel-3A', ]:
+    for platform_name in ['Sentinel-3B', ]:
         tohdf5(SlstrRSR, platform_name, SLSTR_BAND_NAMES)
 
 


### PR DESCRIPTION
Just a simple update to provide spectral response functions for SLSTR on Sentinel 3B

 - [x] Closes #96  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
