### PR TITLE
Add support for FCI

### DIFF
--- a/doc/platforms_supported.rst
+++ b/doc/platforms_supported.rst
@@ -88,6 +88,10 @@ have been included in PySpectral.
     * - Metop-SG-A1 MetImage
       - `rsr_metimage_Metop-SG-A1.h5`
       - NWPSAF-MetImage_
+    * - Meteosat-12 fci
+      - `rsr_fci_Meteosat-12.h5`
+      - NWPSAF-Meteosat-12-fci_
+
 
 .. _Eumetsat: https://www.eumetsat.int/website/home/Data/Products/Calibration/MSGCalibration/index.html
 .. _GSICS: https://www.star.nesdis.noaa.gov/smcd/GCC/instrInfo-srf.php
@@ -102,4 +106,5 @@ have been included in PySpectral.
 .. _CMA: http://www.cma.gov.cn/en2014/
 .. _NWPSAF-MetImage: https://nwpsaf.eu/downloads/rtcoef_rttov12/ir_srf/rtcoef_metopsg_1_metimage_srf.html
 .. _NWPSAF-GeoKompsat-2A-ami: https://nwpsaf.eu/downloads/rtcoef_rttov12/ir_srf/rtcoef_gkompsat2_1_ami_srf.html
+.. _NWPSAF-Meteosat-12-fci: https://nwpsaf.eu/downloads/rtcoef_rttov12/ir_srf/rtcoef_mtg_1_fci_srf.html
 .. _NSMC-fy4a: http://fy4.nsmc.org.cn/portal/cn/fycv/srf.html

--- a/doc/platforms_supported.rst
+++ b/doc/platforms_supported.rst
@@ -91,6 +91,9 @@ have been included in PySpectral.
     * - Meteosat-12 fci
       - `rsr_fci_Meteosat-12.h5`
       - NWPSAF-Meteosat-12-fci_
+    * - MTG-I1 fci (NB! Identical to Meteosat-12 fci)
+      - `rsr_fci_MTG-I1.h5`
+      - NWPSAF-Meteosat-12-fci_
 
 
 .. _Eumetsat: https://www.eumetsat.int/website/home/Data/Products/Calibration/MSGCalibration/index.html

--- a/doc/platforms_supported.rst
+++ b/doc/platforms_supported.rst
@@ -61,6 +61,9 @@ have been included in PySpectral.
     * - Sentinel-3A slstr
       - `rsr_slstr_Sentinel-3A.h5`
       - ESA-Sentinel-SLSTR_
+    * - Sentinel-3B slstr
+      - `rsr_slstr_Sentinel-3B.h5`
+      - ESA-Sentinel-SLSTR_
     * - Sentinel-3A olci
       - `rsr_olci_Sentinel-3A.h5`
       - ESA-Sentinel-OLCI_
@@ -102,7 +105,7 @@ have been included in PySpectral.
 .. _JMA: http://www.data.jma.go.jp/mscweb/en/himawari89/space_segment/spsg_ahi.html#srf
 .. _ESA-Envisat: http://envisat.esa.int/handbooks/aatsr/aux-files/consolidatedsrfs.xls
 .. _ESA-Sentinel-OLCI: https://sentinel.esa.int/documents/247904/322304/OLCI+SRF+%28NetCDF%29/15cfd7a6-b7bc-4051-87f8-c35d765ae43a
-.. _ESA-Sentinel-SLSTR: https://sentinel.esa.int/documents/247904/322305/SLSTR_FM02_Spectral_Responses_Necdf_zip/3a4482b8-6e44-47f3-a8f2-79c000663976
+.. _ESA-Sentinel-SLSTR: https://sentinel.esa.int/web/sentinel/technical-guides/sentinel-3-slstr/instrument/measured-spectral-response-function-data
 .. _ESA-Sentinel-MSI: https://earth.esa.int/documents/247904/685211/S2-SRF_COPE-GSEG-EOPG-TN-15-0007_3.0.xlsx
 .. _NASA-Landsat-OLI: https://landsat.gsfc.nasa.gov/wp-content/uploads/2013/06/Ball_BA_RSR.v1.1-1.xlsx
 .. _NESDIS: https://ncc.nesdis.noaa.gov/J1VIIRS/J1VIIRSSpectralResponseFunctions.php

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2014-2019 Pytroll
+# Copyright (c) 2014-2020 Pytroll
 
 # Author(s):
 
@@ -156,9 +156,9 @@ INSTRUMENTS = {'NOAA-19': 'avhrr/3',
                }
 
 
-HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/3667766/files/pyspectral_rsr_data.tgz"
+HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/3786824/files/pyspectral_rsr_data.tgz"
 RSR_DATA_VERSION_FILENAME = "PYSPECTRAL_RSR_VERSION"
-RSR_DATA_VERSION = "v1.0.11"
+RSR_DATA_VERSION = "v1.0.12"
 
 ATM_CORRECTION_LUT_VERSION = {}
 ATM_CORRECTION_LUT_VERSION['antarctic_aerosol'] = {'version': 'v1.0.1',

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -128,6 +128,24 @@ BANDNAMES['ami'] = {'VI004': 'ch1',
                     'IR133': 'ch16'
                     }
 
+BANDNAMES['fci'] = {'vis_04': 'ch1',
+                    'vis_05': 'ch2',
+                    'vis_06': 'ch3',
+                    'vis_08': 'ch4',
+                    'vis_09': 'ch5',
+                    'nir_13': 'ch6',
+                    'nir_16': 'ch7',
+                    'nir_22': 'ch8',
+                    'ir_38': 'ch9',
+                    'wv_63': 'ch10',
+                    'wv_73': 'ch11',
+                    'ir_87': 'ch12',
+                    'ir_97': 'ch13',
+                    'ir_105': 'ch14',
+                    'ir_123': 'ch15',
+                    'ir_133': 'ch16'
+                    }
+
 INSTRUMENTS = {'NOAA-19': 'avhrr/3',
                'NOAA-18': 'avhrr/3',
                'NOAA-17': 'avhrr/3',
@@ -157,10 +175,11 @@ INSTRUMENTS = {'NOAA-19': 'avhrr/3',
                }
 
 
-HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/3813418/files/pyspectral_rsr_data.tgz"
+HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/3813522/files/pyspectral_rsr_data.tgz"
+
 
 RSR_DATA_VERSION_FILENAME = "PYSPECTRAL_RSR_VERSION"
-RSR_DATA_VERSION = "v1.0.13"
+RSR_DATA_VERSION = "v1.0.14"
 
 ATM_CORRECTION_LUT_VERSION = {}
 ATM_CORRECTION_LUT_VERSION['antarctic_aerosol'] = {'version': 'v1.0.1',

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -152,13 +152,15 @@ INSTRUMENTS = {'NOAA-19': 'avhrr/3',
                'FY-3B': 'virr',
                'Feng-Yun 3D': 'mersi-2',
                'FY-4A': 'agri',
-               'GEO-KOMPSAT-2A': 'ami'
+               'GEO-KOMPSAT-2A': 'ami',
+               'MTG-I1': 'fci'
                }
 
 
-HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/3786824/files/pyspectral_rsr_data.tgz"
+HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/3813418/files/pyspectral_rsr_data.tgz"
+
 RSR_DATA_VERSION_FILENAME = "PYSPECTRAL_RSR_VERSION"
-RSR_DATA_VERSION = "v1.0.12"
+RSR_DATA_VERSION = "v1.0.13"
 
 ATM_CORRECTION_LUT_VERSION = {}
 ATM_CORRECTION_LUT_VERSION['antarctic_aerosol'] = {'version': 'v1.0.1',

--- a/rsr_convert_scripts/fci_rsr.py
+++ b/rsr_convert_scripts/fci_rsr.py
@@ -75,9 +75,7 @@ class FciRSR(InstrumentRSR):
         wavelength = 1. / data['wavenumber'] * scale
         response = data['response']
 
-        # The real AMI has more than one detectors I assume. However, for now
-        # we store the single rsr available in the NWPSAF coefficient files:
-        self.rsr = {'wavelength': wavelength, 'response': response}
+        self.rsr = {'wavelength': wavelength[::-1], 'response': response[::-1]}
 
 
 def main():

--- a/rsr_convert_scripts/fci_rsr.py
+++ b/rsr_convert_scripts/fci_rsr.py
@@ -20,8 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""
-Read the MTG FCI relative spectral response functions.
+"""Read the MTG FCI relative spectral response functions.
 
 Data from EUMETSAT NWP-SAF:
 https://nwpsaf.eu/downloads/rtcoef_rttov12/ir_srf/rtcoef_mtg_1_fci_srf.html

--- a/rsr_convert_scripts/fci_rsr.py
+++ b/rsr_convert_scripts/fci_rsr.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2020 Pytroll Community
+
+# Author(s):
+
+#   Adam.Dybbroe <adam.dybbroe@smhi.se>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Read the MTG FCI relative spectral response functions.
+Data from EUMETSAT NWP-SAF:
+https://nwpsaf.eu/downloads/rtcoef_rttov12/ir_srf/rtcoef_mtg_1_fci_srf.html
+"""
+
+import os
+import numpy as np
+from pyspectral.utils import INSTRUMENTS
+from pyspectral.utils import convert2hdf5 as tohdf5
+from pyspectral.raw_reader import InstrumentRSR
+import logging
+
+LOG = logging.getLogger(__name__)
+
+FCI_BAND_NAMES = ['ch1', 'ch2', 'ch3', 'ch4', 'ch5', 'ch6', 'ch7', 'ch8', 'ch9', 'ch10',
+                  'ch11', 'ch12', 'ch13', 'ch14', 'ch15', 'ch16']
+
+
+class FciRSR(InstrumentRSR):
+
+    """Container for the MTG FCI RSR data"""
+
+    def __init__(self, bandname, platform_name):
+
+        super(FciRSR, self).__init__(bandname, platform_name, FCI_BAND_NAMES)
+
+        self.instrument = 'fci'
+
+        self._get_options_from_config()
+        self._get_bandfilenames()
+
+        LOG.debug("Filenames: %s", str(self.filenames))
+        if self.filenames[bandname] and os.path.exists(self.filenames[bandname]):
+            self.requested_band_filename = self.filenames[bandname]
+            self._load()
+
+        else:
+            LOG.warning("Couldn't find an existing file for this band: %s",
+                        str(self.bandname))
+
+        # To be compatible with VIIRS....
+        self.filename = self.requested_band_filename
+
+    def _load(self, scale=10000.0):
+        """Load the FCI RSR data for the band requested"""
+        data = np.genfromtxt(self.requested_band_filename,
+                             unpack=True,
+                             names=['wavenumber',
+                                    'response'],
+                             skip_header=4)
+
+        # Data are wavenumbers in cm-1:
+        wavelength = 1. / data['wavenumber'] * scale
+        response = data['response']
+
+        # The real AMI has more than one detectors I assume. However, for now
+        # we store the single rsr available in the NWPSAF coefficient files:
+        self.rsr = {'wavelength': wavelength, 'response': response}
+
+
+def main():
+    """Main"""
+    for platform_name in ["Meteosat-12", ]:
+        tohdf5(FciRSR, platform_name, FCI_BAND_NAMES)
+
+
+if __name__ == "__main__":
+    main()

--- a/rsr_convert_scripts/fci_rsr.py
+++ b/rsr_convert_scripts/fci_rsr.py
@@ -21,16 +21,16 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Read the MTG FCI relative spectral response functions.
+
 Data from EUMETSAT NWP-SAF:
 https://nwpsaf.eu/downloads/rtcoef_rttov12/ir_srf/rtcoef_mtg_1_fci_srf.html
 """
 
 import os
+import logging
 import numpy as np
-from pyspectral.utils import INSTRUMENTS
 from pyspectral.utils import convert2hdf5 as tohdf5
 from pyspectral.raw_reader import InstrumentRSR
-import logging
 
 LOG = logging.getLogger(__name__)
 
@@ -40,10 +40,10 @@ FCI_BAND_NAMES = ['ch1', 'ch2', 'ch3', 'ch4', 'ch5', 'ch6', 'ch7', 'ch8', 'ch9',
 
 class FciRSR(InstrumentRSR):
 
-    """Container for the MTG FCI RSR data"""
+    """Container for the MTG FCI RSR data."""
 
     def __init__(self, bandname, platform_name):
-
+        """Setup the MTG FCI RSR data container."""
         super(FciRSR, self).__init__(bandname, platform_name, FCI_BAND_NAMES)
 
         self.instrument = 'fci'
@@ -64,7 +64,7 @@ class FciRSR(InstrumentRSR):
         self.filename = self.requested_band_filename
 
     def _load(self, scale=10000.0):
-        """Load the FCI RSR data for the band requested"""
+        """Load the FCI RSR data for the band requested."""
         data = np.genfromtxt(self.requested_band_filename,
                              unpack=True,
                              names=['wavenumber',
@@ -79,7 +79,7 @@ class FciRSR(InstrumentRSR):
 
 
 def main():
-    """Main"""
+    """Main function creating the internal Pyspectral hdf5 output for FCI."""
     for platform_name in ["Meteosat-12", 'MTG-I1']:
         tohdf5(FciRSR, platform_name, FCI_BAND_NAMES)
 

--- a/rsr_convert_scripts/fci_rsr.py
+++ b/rsr_convert_scripts/fci_rsr.py
@@ -20,7 +20,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Read the MTG FCI relative spectral response functions.
+"""
+Read the MTG FCI relative spectral response functions.
 
 Data from EUMETSAT NWP-SAF:
 https://nwpsaf.eu/downloads/rtcoef_rttov12/ir_srf/rtcoef_mtg_1_fci_srf.html
@@ -39,7 +40,6 @@ FCI_BAND_NAMES = ['ch1', 'ch2', 'ch3', 'ch4', 'ch5', 'ch6', 'ch7', 'ch8', 'ch9',
 
 
 class FciRSR(InstrumentRSR):
-
     """Container for the MTG FCI RSR data."""
 
     def __init__(self, bandname, platform_name):

--- a/rsr_convert_scripts/fci_rsr.py
+++ b/rsr_convert_scripts/fci_rsr.py
@@ -82,7 +82,7 @@ class FciRSR(InstrumentRSR):
 
 def main():
     """Main"""
-    for platform_name in ["Meteosat-12", ]:
+    for platform_name in ["Meteosat-12", 'MTG-I1']:
         tohdf5(FciRSR, platform_name, FCI_BAND_NAMES)
 
 

--- a/rsr_convert_scripts/seviri_rsr.py
+++ b/rsr_convert_scripts/seviri_rsr.py
@@ -2,7 +2,7 @@
 
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2013-2018 Adam.Dybbroe
+# Copyright (c) 2013-2018, 2020 Pytroll Community
 
 # Author(s):
 


### PR DESCRIPTION
Adding support for the MTG-I1 FCI instrument: Adding a conversion script to read the original RSR data (from NWPSAF - RTTOV) and convert to the internal hdf5 format. New hdf5 internal formatet data uploaded to Zenodo, and list of supported platforms updated.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
