### PR TITLE
Add option to specify sun-zenith angle threshold applied

### DIFF
--- a/pyspectral/near_infrared_reflectance.py
+++ b/pyspectral/near_infrared_reflectance.py
@@ -66,7 +66,7 @@ class Calculator(RadTbConverter):
     """
 
     def __init__(self, platform_name, instrument, band,
-                 detector='det-1', wavespace='wavelength',
+                 detector='det-1', wavespace=WAVE_LENGTH,
                  solar_flux=None, sunz_threshold=TERMINATOR_LIMIT):
         """Initialize the Class instance."""
         super(Calculator, self).__init__(platform_name, instrument, band, detector=detector, wavespace=wavespace)

--- a/pyspectral/radiance_tb_conversion.py
+++ b/pyspectral/radiance_tb_conversion.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2014-2019 Adam.Dybbroe
+# Copyright (c) 2014-2020 Adam.Dybbroe
 
 # Author(s):
 
@@ -99,7 +99,8 @@ class RadTbConverter(object):
 
     """
 
-    def __init__(self, platform_name, instrument, band, **options):
+    def __init__(self, platform_name, instrument, band, detector='det-1', wavespace=WAVE_LENGTH,
+                 tb_resolution=0.1):
         """Initialize the Class instance.
 
         E.g.:
@@ -116,7 +117,7 @@ class RadTbConverter(object):
         self.bandwavelength = None
         self.band = band
 
-        self.wavespace = options.get('wavespace', WAVE_LENGTH)
+        self.wavespace = wavespace
         if self.wavespace not in [WAVE_LENGTH, WAVE_NUMBER]:
             raise AttributeError('Wave space not {0} or {1}!'.format(WAVE_LENGTH,
                                                                      WAVE_NUMBER))
@@ -124,8 +125,8 @@ class RadTbConverter(object):
         self._wave_unit = 'm'
         self._wave_si_scale = 1.0
 
-        self.detector = options.get('detector', 'det-1')
-        self.tb_resolution = options.get('tb_resolution', 0.1)
+        self.detector = detector
+        self.tb_resolution = tb_resolution
         self.tb_scale = 1. / self.tb_resolution
 
         self.blackbody_function = BLACKBODY_FUNC[self.wavespace]


### PR DESCRIPTION
Add option to specify sun-zenith angle threshold in the 3.x emissive/reflectance separation, and set default to 85 (instead of 88)


 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
