### PR TITLE
add more realistic METimage RSRs

### DIFF
--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -175,11 +175,11 @@ INSTRUMENTS = {'NOAA-19': 'avhrr/3',
                }
 
 
-HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/3813522/files/pyspectral_rsr_data.tgz"
+HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/3824535/files/pyspectral_rsr_data.tgz"
 
 
 RSR_DATA_VERSION_FILENAME = "PYSPECTRAL_RSR_VERSION"
-RSR_DATA_VERSION = "v1.0.14"
+RSR_DATA_VERSION = "v1.0.15"
 
 ATM_CORRECTION_LUT_VERSION = {}
 ATM_CORRECTION_LUT_VERSION['antarctic_aerosol'] = {'version': 'v1.0.1',

--- a/rsr_convert_scripts/metimage_rsr.py
+++ b/rsr_convert_scripts/metimage_rsr.py
@@ -21,8 +21,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Read the preliminary MetImage relative spectral response functions.
-Data from the NWPSAF, These are very early theoretical and idealized versions,
-derived from specifications I assume.
+Data from the NWPSAF, These are simulated function.
 
 """
 
@@ -68,16 +67,17 @@ class MetImageRSR(InstrumentRSR):
         self.unit = 'micrometer'
         self.wavespace = 'wavelength'
 
-    def _load(self, scale=1.0):
+    def _load(self, scale=0.001):
         """Load the MetImage RSR data for the band requested"""
         data = np.genfromtxt(self.requested_band_filename,
                              unpack=True,
-                             names=['wavenumber',
+                             names=['wavelength',
                                     'response'],
-                             skip_header=4)
+                             skip_header=0,
+                             delimiter=',')
 
-        # Data are wavenumbers in cm-1:
-        wavelength = 1. / data['wavenumber'] * 10000.
+        # Data are in nanometer and need to transform to microns:
+        wavelength = data['wavelength'] * scale
         response = data['response']
 
         # The real MetImage has 24 detectors. However, for now we store the


### PR DESCRIPTION
Updated to more realistic, though not measured spectral response functions for METimage

<!-- Describe what your PR does, and why -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
