### PR TITLE
Add bandname mapping for slstr

### DIFF
--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -146,6 +146,19 @@ BANDNAMES['fci'] = {'vis_04': 'ch1',
                     'ir_133': 'ch16'
                     }
 
+BANDNAMES['slstr'] = {'S1': 'ch1',
+                      'S2': 'ch2',
+                      'S3': 'ch3',
+                      'S4': 'ch4',
+                      'S5': 'ch5',
+                      'S6': 'ch6',
+                      'S7': 'ch7',
+                      'S8': 'ch8',
+                      'S9': 'ch9',
+                      'F1': 'ch7',
+                      'F2': 'ch8',
+                      }
+
 INSTRUMENTS = {'NOAA-19': 'avhrr/3',
                'NOAA-18': 'avhrr/3',
                'NOAA-17': 'avhrr/3',


### PR DESCRIPTION
This adds bandnames for SLSTR

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->

