### PR TITLE
Separate masking and Sun zenith angle correction

### DIFF
--- a/doc/seviri_example.rst
+++ b/doc/seviri_example.rst
@@ -27,7 +27,7 @@ reflectance, saving a few milliseconds per call::
 
 By default the data are masked outside the default Sun zenith-angle (SZA) correction limit (85.0 degrees).
 The masking can be adjusted via `masking_limit` keyword argument to `Calculator`, and turned of by
-defining `Calculator(..., masking_limit=None)`.  The SZA limit can be adjusted via `sunz_threshold keyword argument:
+defining `Calculator(..., masking_limit=None)`.  The SZA limit can be adjusted via `sunz_threshold` keyword argument:
 `Calculator(..., sunz_threshold=88.0)`.
 
 Integration with SatPy

--- a/doc/seviri_example.rst
+++ b/doc/seviri_example.rst
@@ -25,6 +25,10 @@ reflectance, saving a few milliseconds per call::
   >>> print('%4.3f' %refl39.reflectance_from_tbs(sunz, tb3, tb4))
   0.555
 
+By default the data are masked outside the default Sun zenith-angle (SZA) correction limit (85.0 degrees).
+The masking can be adjusted via `masking_limit` keyword argument to `Calculator`, and turned of by
+defining `Calculator(..., masking_limit=None)`.  The SZA limit can be adjusted via `sunz_threshold keyword argument:
+`Calculator(..., sunz_threshold=88.0)`.
 
 Integration with SatPy
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/pyspectral/tests/test_reflectance.py
+++ b/pyspectral/tests/test_reflectance.py
@@ -156,8 +156,9 @@ class TestReflectance(unittest.TestCase):
 
             refl37 = Calculator('EOS-Aqua', 'modis', '20')
 
-            refl37_sz88 = Calculator('EOS-Aqua', 'modis', '20', sunz_threshold=88.0)
+            refl37_sz88 = Calculator('EOS-Aqua', 'modis', '20', sunz_threshold=88.0, masking_limit=None)
             self.assertEqual(refl37_sz88.sunz_threshold, 88.0)
+            self.assertIsNone(refl37_sz88.masking_limit)
             self.assertAlmostEqual(refl37_sz88.bandwavelength, 3.780282, 5)
             self.assertEqual(refl37_sz88.bandname, '20')
 

--- a/pyspectral/tests/test_reflectance.py
+++ b/pyspectral/tests/test_reflectance.py
@@ -22,7 +22,7 @@
 
 """Unit testing the 3.7 micron reflectance calculations."""
 
-from pyspectral.near_infrared_reflectance import Calculator
+from pyspectral.near_infrared_reflectance import Calculator, TERMINATOR_LIMIT
 import numpy as np
 import sys
 if sys.version_info < (2, 7):
@@ -155,6 +155,8 @@ class TestReflectance(unittest.TestCase):
             instance.si_scale = 1e-6
 
             refl37 = Calculator('EOS-Aqua', 'modis', '20')
+            self.assertEqual(refl37.sunz_threshold, TERMINATOR_LIMIT)
+            self.assertEqual(refl37.masking_limit, TERMINATOR_LIMIT)
 
             refl37_sz88 = Calculator('EOS-Aqua', 'modis', '20', sunz_threshold=88.0, masking_limit=None)
             self.assertEqual(refl37_sz88.sunz_threshold, 88.0)


### PR DESCRIPTION
This PR separates the Sun zenith-angle correction and masking of data beyond given SZA limit.

 - [x] Closes #112  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
