### PR TITLE
Update travis tests to use python 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,14 @@ env:
 
 matrix:
   include:
-    - env: PYTHON_VERSION=2.7
+    - env: PYTHON_VERSION=3.7
       os: linux
-    - env: PYTHON_VERSION=2.7
+    - env: PYTHON_VERSION=3.7
       os: osx
       language: generic
-    - env: PYTHON_VERSION=3.6
+    - env: PYTHON_VERSION=3.8
       os: linux
-    - env: PYTHON_VERSION=3.6
+    - env: PYTHON_VERSION=3.8
       os: osx
       language: generic
 install:
@@ -33,7 +33,7 @@ install:
 script:
   - py.test  --cov-report term --cov=./
 after_success:
-- if [[ $PYTHON_VERSION == 3.6 ]]; then coveralls; fi
+- if [[ $PYTHON_VERSION == 3.8 ]]; then coveralls; fi
 deploy:
   - provider: pypi
     user: adybbroe


### PR DESCRIPTION
This drops python 2.7 and 3.6.

