### PR TITLE
Fix documentation error in SI unit conversion

### DIFF
--- a/pyspectral/blackbody.py
+++ b/pyspectral/blackbody.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2013-2019 Adam.Dybbroe
+# Copyright (c) 2013-2020 Adam.Dybbroe
 
 # Author(s):
 
@@ -140,7 +140,7 @@ def planck(wave, temperature, wavelength=True):
             Unit = W/m^2 sr^-1 (m^-1)^-1 = W/m sr^-1
 
             Converting from SI units to mW/m^2 sr^-1 (cm^-1)^-1:
-            1.0 W/m^2 sr^-1 (m^-1)^-1 = 0.1 mW/m^2 sr^-1 (cm^-1)^-1
+            1.0 W/m^2 sr^-1 (m^-1)^-1 = 1.0e5 mW/m^2 sr^-1 (cm^-1)^-1
 
     """
     units = ['wavelengths', 'wavenumbers']


### PR DESCRIPTION
Fix an error in the API documentation of the planck radiation concrning conversion from SI units to ` mW/m^2 sr^-1 (cm^-1)^-1`

 - [x] Closes #111 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
