### PR TITLE
Update documentation with new satellites / sensors and correct typos

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -9,7 +9,7 @@ Some static data are part of the package. Downloading of this data is handled
 automagically by the software when data are needed. However, the data can also
 be downloaded manually once and for all by calling dedicated download
 scripts. The latter is helpful when running PySpectral in an operational
-environemnt. See further below on how the static data downloads are handled.
+environment. See further below on how the static data downloads are handled.
 
 You can also choose to download the PySpectral source code from github_::
 
@@ -57,7 +57,7 @@ data`_. But far from all data are available through that web-site.
 
 Therefore, in order to make life easier for the *PySpectral* user we have
 defined one common internal HDF5 format. That way it is also easy to add
-support for new instruments. Currently the relative spectral reponses for the
+support for new instruments. Currently the relative spectral responses for the
 following sensors are included:
 
  * Suomi-NPP and NOAA-20 VIIRS
@@ -66,10 +66,12 @@ following sensors are included:
  * Meteosat 8-11 SEVIRI
  * Sentinel-3A/3B SLSTR and OLCI
  * Envisat AATSR
- * GOES-16 ABI
- * Himawari-8 AHI
+ * GOES-16/17 ABI
+ * Himawari-8/9 AHI
  * Sentinel-2 A&B MSI
  * Landsat-8 OLI
+ * Geo-Kompsat-2A / AMI
+ * Fengyun-4A / AGRI
 
 The data are automagically downloaded and installed when needed. But if you
 need to specifically retrieve the data independently the data are available
@@ -92,8 +94,8 @@ using verbose mode (to get some log information on the screen):
    
 
 It is still also possible to download the original spectral responses from the
-various satellite operators instead and generate the internal HDF5 formatet
-files yourself. However, this should normaly never be needed. (For SEVIRI on
+various satellite operators instead and generate the internal HDF5 formatted
+files yourself. However, this should normally never be needed. (For SEVIRI on
 Meteosat download the data from eumetsat_ and unzip the Excel file.)
 
 
@@ -102,7 +104,7 @@ Look-Up-Tables for atmospheric correction in the SW spectral range
 
 Look-Up-Tables (LUTs) with simulated black surface top of atmosphere
 reflectances over the :math:`400-600 nm` wavelength spectrum for various
-aerosol distributions and a set of standard atmosdot-heres for varying
+aerosol distributions and a set of standard atmospheres for varying
 sun-satellite viewing are available in HDF5 on `zenodo.org`_. The LUTs are
 downloaded automagically when needed and placed in the same directory structure
 as the spectral response data (see above). The data can also be downloaded
@@ -135,7 +137,7 @@ this configuration file, as e.g.::
 
   $> PSP_CONFIG_FILE=/home/a000680/pyspectral.yaml; export PSP_CONFIG_FILE
 
-So, in case you want to download the internal *PySpectral* formatet relative
+So, in case you want to download the internal *PySpectral* formatted relative
 spectral responses as well as the atmospheric correction LUTs once and for all,
 and keep them somewhere else. Change the configuration in *pyspectral.yaml* so
 it looks something like this:

--- a/doc/platforms_supported.rst
+++ b/doc/platforms_supported.rst
@@ -25,6 +25,9 @@ have been included in PySpectral.
     * - GOES-16 abi
       - `rsr_abi_GOES-16.h5`
       - GOES-R_
+    * - GOES-17 abi
+      - `rsr_abi_GOES-17.h5`
+      - GOES-S_
     * - Himawari-8 ahi
       - `rsr_ahi_Himawari-8.h5`
       - JMA_
@@ -102,6 +105,7 @@ have been included in PySpectral.
 .. _Eumetsat: https://www.eumetsat.int/website/home/Data/Products/Calibration/MSGCalibration/index.html
 .. _GSICS: https://www.star.nesdis.noaa.gov/smcd/GCC/instrInfo-srf.php
 .. _GOES-R: http://ncc.nesdis.noaa.gov/GOESR/docs/GOES-R_ABI_PFM_SRF_CWG_v3.zip
+.. _GOES-S:  http://ncc.nesdis.noaa.gov/GOESR/docs/GOES-R_ABI_FM2_SRF_CWG.zip
 .. _JMA: http://www.data.jma.go.jp/mscweb/en/himawari89/space_segment/spsg_ahi.html#srf
 .. _ESA-Envisat: http://envisat.esa.int/handbooks/aatsr/aux-files/consolidatedsrfs.xls
 .. _ESA-Sentinel-OLCI: https://sentinel.esa.int/documents/247904/322304/OLCI+SRF+%28NetCDF%29/15cfd7a6-b7bc-4051-87f8-c35d765ae43a

--- a/doc/rad_definitions.rst
+++ b/doc/rad_definitions.rst
@@ -187,7 +187,7 @@ In python code it may look like this:
    >>> from pyspectral.solar import (SolarIrradianceSpectrum, TOTAL_IRRADIANCE_SPECTRUM_2000ASTM)
    >>> solar_irr = SolarIrradianceSpectrum(TOTAL_IRRADIANCE_SPECTRUM_2000ASTM, dlambda=0.0005, wavespace='wavenumber')
    >>> print("Solar Irrdiance (SEVIRI band VIS008) = {sflux:12.6f}".format(sflux=solar_irr.inband_solarflux(rsr['VIS0.8'])))
-   Solar Irrdiance (SEVIRI band VIS008) = 63767.908405
+   Solar Irradiance (SEVIRI band VIS008) = 63767.908405
 
 
 Planck radiation

--- a/doc/rayleigh_correction.rst
+++ b/doc/rayleigh_correction.rst
@@ -1,4 +1,4 @@
-Atmospherioc correction in the visible spectrum
+Atmospheric correction in the visible spectrum
 -----------------------------------------------
 
 .. figure:: _static/truecolor_composite_20170518_nrk_reception_cropped_thumb.png
@@ -17,8 +17,8 @@ imagery.
 
 In order to correct for this atmospheric effect we have simulated the solar
 reflectance under various sun-satellite viewing conditions for a set of
-different standard atmospheres, asuming a black surface, using a radiative
-transfer model. For a given atmosphere the reflectance is dependent on wavelenght,
+different standard atmospheres, assuming a black surface, using a radiative
+transfer model. For a given atmosphere the reflectance is dependent on wavelength,
 solar-zenith angle, satellite zenith angle, and the relative sun-satellite
 azimuth difference angle:
 
@@ -35,7 +35,7 @@ in the figure below:
    :scale: 70%
    :align: center
 
-The method is descriped in detail in a `scientific paper`_.
+The method is described in detail in a `scientific paper`_.
 
 To apply the atmospheric correction for a given satellite sensor band, the
 procedure involves the following three steps:
@@ -47,7 +47,7 @@ procedure involves the following three steps:
 As the Rayleigh scattering, which is the dominating part we are correcting for
 under normal situations (when there is no excessive pollution or aerosols in
 the line of sight) is proportional to :math:`\frac{1}{{\lambda}^4}` the
-effective wavelength is derived by convolving the spectral response with
+effective wavelength is derived by convolution of the spectral response with
 :math:`\frac{1}{{\lambda}^4}`. 
 
 To get the atmospheric contribution for an arbitrary band, first the

--- a/doc/rsr_plotting.rst
+++ b/doc/rsr_plotting.rst
@@ -32,7 +32,7 @@ MERSI-2 on FY-3D:
 
 It is possible to specify a different wavelength resolution/increments by using
 a flag. However, when you do that it might affect how pyspectral identify
-bands. If the resolution is too coarse svereal close bands may be considered
+bands. If the resolution is too coarse several close bands may be considered
 one and the same. In the below case it is probably not a good idea to lower the
 resolution as one can see (several MESI-2 bands are now missing):
 


### PR DESCRIPTION
I noticed that some of the documentation is a bit outdated, and does not include the full list of satellite / sensors supported by Pyspectral.
This PR corrects the docs to list all supported sats (to my knowledge) and along the way I've also corrected some typos.
