### PR TITLE
Fix scale of AGRI response values

### DIFF
--- a/rsr_convert_scripts/agri_rsr.py
+++ b/rsr_convert_scripts/agri_rsr.py
@@ -90,7 +90,7 @@ class AGRIRSR(InstrumentRSR):
                              skip_header=0)
 
         wavelength = data['wavelength'] * scale
-        response = data['response']
+        response = data['response'] / 100.
 
         self.rsr = {'wavelength': wavelength, 'response': response}
 


### PR DESCRIPTION
Within pyspectral, the response functions for instruments are in the range 0->1.
However, the raw AGRI spectral responses are scaled between 0->100 and must be converted into the correct range during processing. This PR updates the AGRI RSR reader to perform this conversion.

 - [x] Tests passed: Passes ``pytest pyspectral``
 - [x] Passes ``flake8 pyspectral``
