### PR TITLE
Add a utility function to decode HDF5 strings

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ environment:
     PYTHON: "C:\\conda"
     MINICONDA_VERSION: "latest"
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
-    CONDA_DEPENDENCIES: "scipy coveralls coverage h5py mock requests six appdirs python-geotiepoints dask docutils pyaml xlrd"
+    CONDA_DEPENDENCIES: "scipy coveralls coverage h5py mock requests six appdirs python-geotiepoints dask docutils pyaml xlrd pytest"
     PIP_DEPENDENCIES: ""
     CONDA_CHANNELS: "conda-forge"
     CONDA_CHANNEL_PRIORITY: "True"

--- a/pyspectral/rsr_reader.py
+++ b/pyspectral/rsr_reader.py
@@ -32,6 +32,7 @@ from pyspectral.utils import WAVE_NUMBER
 from pyspectral.utils import WAVE_LENGTH
 from pyspectral.utils import (INSTRUMENTS, download_rsr)
 from pyspectral.utils import (RSR_DATA_VERSION_FILENAME, RSR_DATA_VERSION)
+from pyspectral.utils import np2str
 
 import logging
 LOG = logging.getLogger(__name__)
@@ -166,18 +167,12 @@ class RelativeSpectralResponse(RSRDataBaseClass):
 
         no_detectors_message = False
         with h5py.File(self.filename, 'r') as h5f:
-            self.band_names = h5f.attrs['band_names'].tolist()
-            self.description = h5f.attrs['description']
-            if not isinstance(self.band_names[0], str):
-                # byte array in python 3
-                self.band_names = [x.decode('utf-8') for x in self.band_names]
-                self.description = self.description.decode('utf-8')
-
+            self.band_names = h5f.attrs['band_names']
+            self.description = np2str(h5f.attrs['description'])
+            self.band_names = [np2str(x) for x in self.band_names]
             if not self.platform_name:
                 try:
-                    self.platform_name = h5f.attrs['platform_name']
-                    if not isinstance(self.platform_name, str):
-                        self.platform_name = self.platform_name.decode('utf-8')
+                    self.platform_name = np2str(h5f.attrs['platform_name'])
                 except KeyError:
                     LOG.warning("No platform_name in HDF5 file")
                     try:
@@ -190,9 +185,7 @@ class RelativeSpectralResponse(RSRDataBaseClass):
 
             if not self.instrument:
                 try:
-                    self.instrument = h5f.attrs['sensor'].decode('utf-8')
-                    if not isinstance(self.instrument, str):
-                        self.instrument = self.instrument.decode('utf-8')
+                    self.instrument = np2str(h5f.attrs['sensor'])
                 except KeyError:
                     LOG.warning("No sensor name specified in HDF5 file")
                     self.instrument = INSTRUMENTS.get(self.platform_name)

--- a/pyspectral/tests/test_utils.py
+++ b/pyspectral/tests/test_utils.py
@@ -176,3 +176,33 @@ class TestUtils(unittest.TestCase):
         wvl_range = utils.get_wave_range(self.rsr.rsr['ch3']['det-1'], 0.5)
         expected_range = [0.60931027, 0.6393011276027835, 0.67512828]
         np.testing.assert_allclose(wvl_range, expected_range)
+
+
+def test_np2str(self):
+    """Test the np2str function."""
+    import pytest
+    from pyspectral.utils import np2str
+    # byte object
+    npstring = np.string_('hej')
+    assert np2str(npstring) == 'hej'
+
+    # single element numpy array
+    np_arr = np.array([npstring])
+    assert np2str(np_arr) == 'hej'
+
+    # scalar numpy array
+    np_arr = np.array(npstring)
+    assert np2str(np_arr) == 'hej'
+
+    # multi-element array
+    npstring = np.array([npstring, npstring])
+    with pytest.raises(ValueError):
+        _ = np2str(npstring)
+
+    # non-array-non-string
+    with pytest.raises(ValueError):
+        _ = np2str(5)
+
+    # pure string
+    pure_str = 'hej'
+    assert np2str(pure_str) is pure_str

--- a/pyspectral/tests/test_utils.py
+++ b/pyspectral/tests/test_utils.py
@@ -178,7 +178,7 @@ class TestUtils(unittest.TestCase):
         np.testing.assert_allclose(wvl_range, expected_range)
 
 
-def test_np2str(self):
+def test_np2str():
     """Test the np2str function."""
     import pytest
     from pyspectral.utils import np2str

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -573,3 +573,26 @@ def get_wave_range(in_chan, threshold=0.15):
     max_wvl = wvls[pts[0][-1]]
 
     return [min_wvl, cwl, max_wvl]
+
+
+def np2str(value):
+    """Convert an `numpy.string_` to str.
+    Args:
+        value (ndarray): scalar or 1-element numpy array to convert
+    Raises:
+        ValueError: if value is array larger than 1-element or it is not of
+                    type `numpy.string_` or it is not a numpy array
+    """
+    if isinstance(value, str):
+        return value
+    if hasattr(value, 'dtype') and \
+            issubclass(value.dtype.type, (np.str_, np.string_, np.object_)) \
+            and value.size == 1:
+        value = value.item()
+        if not isinstance(value, str):
+            # python 3 - was scalar numpy array of bytes
+            # otherwise python 2 - scalar numpy array of 'str'
+            value = value.decode()
+        return value
+    else:
+        raise ValueError("Array is not a string type or is larger than 1")

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ requires = ['docutils>=0.3', 'numpy>=1.5.1', 'scipy>=0.14',
             'appdirs']
 
 dask_extra = ['dask[array]']
-test_requires = ['pyyaml', 'dask[array]', 'xlrd']  # , 'matplotlib']
+test_requires = ['pyyaml', 'dask[array]', 'xlrd', 'pytest']  # , 'matplotlib']
 if sys.version < '3.0':
     test_requires.append('mock')
     try:


### PR DESCRIPTION
This PR adds a helper function that handles all the HDF5 strings and decoding them to UTF-8 if necessary.

 - [x] Closes #122  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
