### PR TITLE
Fix and revert geokompsat2a ami rsr

### DIFF
--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -609,8 +609,8 @@ def np2str(value):
         if not isinstance(value, str):
             return value.decode()
         return value
-    else:
-        raise ValueError("Array is not a string type or is larger than 1")
+
+    raise ValueError("Array is not a string type or is larger than 1")
 
 
 def bytes2string(var):

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -194,11 +194,10 @@ INSTRUMENTS = {'NOAA-19': 'avhrr/3',
                }
 
 
-HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/3824535/files/pyspectral_rsr_data.tgz"
-
+HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/4305549/files/pyspectral_rsr_data.tgz"
 
 RSR_DATA_VERSION_FILENAME = "PYSPECTRAL_RSR_VERSION"
-RSR_DATA_VERSION = "v1.0.15"
+RSR_DATA_VERSION = "v1.0.16"
 
 ATM_CORRECTION_LUT_VERSION = {}
 ATM_CORRECTION_LUT_VERSION['antarctic_aerosol'] = {'version': 'v1.0.1',

--- a/rsr_convert_scripts/ami_reader.py
+++ b/rsr_convert_scripts/ami_reader.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019 Pytroll developers
+# Copyright (c) 2019, 2020 Pytroll developers
 #
 # Author(s):
 #
@@ -82,8 +82,8 @@ class AmiRSR(InstrumentRSR):
                              skip_header=4)
 
         # Data are wavenumbers in cm-1:
-        wavelength = 1. / data['wavenumber'] * scale
-        response = data['response']
+        wavelength = 1. / data['wavenumber'][::-1] * scale
+        response = data['response'][::-1]
 
         # The real AMI has more than one detectors I assume. However, for now
         # we store the single rsr available in the NWPSAF coefficient files:

--- a/rsr_convert_scripts/mersi2_rsr.py
+++ b/rsr_convert_scripts/mersi2_rsr.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2018 Pytroll developers
+# Copyright (c) 2018, 2020 Pytroll developers
 #
 # Author(s):
 #
@@ -20,8 +20,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Read the MERSI-II relative spectral responses. Data from xuna@cma.gov.cn
-(Personal contact with Sara Hörnquist, SMHI).
+"""Read the MERSI-II relative spectral responses.
+
+Data available from NSMC:
+http://gsics.nsmc.org.cn/portal/en/fycv/srf.html
+http://gsics.nsmc.org.cn/download/documents/SRF/FY3D_MERSI_SRF_Pub.zip
 """
 import os
 import numpy as np


### PR DESCRIPTION
This is supposed to fix issue #89 The GK2A ami data had its rsr data ordered so that wavelengths arrays were decreasing.
A new dataset is uploaded to Zenodo:
https://zenodo.org/record/4305549/files/pyspectral_rsr_data.tgz

 - [x] Closes #89  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
