### PR TITLE
Fix dask compatibility of IR atmospherical correction

### DIFF
--- a/pyspectral/atm_correction_ir.py
+++ b/pyspectral/atm_correction_ir.py
@@ -159,5 +159,5 @@ if __name__ == "__main__":
     NDIM = SHAPE[0] * SHAPE[1]
     SATZ = np.ma.arange(NDIM).reshape(SHAPE) * 60. / float(NDIM)
     TBS = np.ma.arange(NDIM).reshape(SHAPE) * 80.0 / float(NDIM) + 220.
-    atm_corr = this.get_correction(SATZ, 'M4', TBS)
+    atm_corr = this.get_correction(da.from_array(SATZ), 'M4', da.from_array(TBS))
 

--- a/pyspectral/atm_correction_ir.py
+++ b/pyspectral/atm_correction_ir.py
@@ -59,6 +59,7 @@ from this time are not longer at DWD.'
 
 
 import numpy as np
+import dask.array as da
 import logging
 
 LOG = logging.getLogger(__name__)
@@ -127,15 +128,38 @@ def viewzen_corr(data, view_zen):
         Z_REF = 70.0
         DELTA_REF = 6.2
         return (1 + DELTA_REF)**ratio(z, Z_0, Z_REF) - 1
-
-    y0, x0 = np.ma.where(view_zen == 0)
-    data[y0, x0] += tau0(data[y0, x0])
-
-    y, x = np.ma.where((view_zen > 0) & (view_zen < 90) & (~data.mask))
-    data[y, x] += tau(data[y, x]) * delta(view_zen[y, x])
-    return data
-
-
+      
+    # not allowed for dask arrays:
+    # - assignment
+    # - access with indexes
+    #
+    # that's why all calculations are done as numpy arrays
+    # special data conversion are needed    
+    # conversion from dask arrays into numpy arrays
+    LOG.debug("Update to process dask array data.") 
+    np_view_zen = np.array(view_zen.compute())
+    np_data = np.ma.masked_array(data.compute())
+    
+    #y0, x0 = np.ma.where(view_zen == 0)
+    y0, x0 = np.ma.where(np_view_zen == 0)
+        
+    # data[y0, x0] += tau0(data[y0, x0])
+    np_data[y0, x0] += tau0(np_data[y0, x0])
+    
+    # y, x = np.ma.where((view_zen > 0) & (view_zen < 90) & (~data.mask))
+    y, x = np.ma.where((np_view_zen > 0) & (np_view_zen < 90) & (~np_data.mask))
+    
+    # data[y, x] += tau(data[y, x]) * delta(view_zen[y, x])
+    np_data[y, x] += tau(np_data[y, x]) * delta(np_view_zen[y, x])
+            
+    LOG.debug( 'Calculated data min/avr/max: {:.3f}/{:.3f}/{:.3f}'.format(np.nanmin(np_data),  \
+                                                                          np.nanmean(np_data), \
+                                                                          np.nanmax(np_data)))
+                                              
+    # back conversion from numpy array into dask array
+    # return data                                              
+    return da.from_array(np_data)
+    
 if __name__ == "__main__":
     this = AtmosphericalCorrection('Suomi-NPP', 'viirs')
     SHAPE = (1000, 3000)
@@ -143,3 +167,4 @@ if __name__ == "__main__":
     SATZ = np.ma.arange(NDIM).reshape(SHAPE) * 60. / float(NDIM)
     TBS = np.ma.arange(NDIM).reshape(SHAPE) * 80.0 / float(NDIM) + 220.
     atm_corr = this.get_correction(SATZ, 'M4', TBS)
+

--- a/pyspectral/atm_correction_ir.py
+++ b/pyspectral/atm_correction_ir.py
@@ -128,15 +128,15 @@ def viewzen_corr(data, view_zen):
         Z_REF = 70.0
         DELTA_REF = 6.2
         return (1 + DELTA_REF)**ratio(z, Z_0, Z_REF) - 1
-      
+
     # not allowed for dask arrays:
     # - assignment
     # - access with indexes
     #
     # that's why all calculations are done as numpy arrays
-    # special data conversion are needed    
+    # special data conversion are needed
     # conversion from dask arrays into numpy arrays
-    LOG.debug("Update to process dask array data.") 
+    LOG.debug("Update to process dask array data.")
     np_view_zen = np.array(view_zen.compute())
     np_data = np.ma.masked_array(data.compute())
     y0, x0 = np.ma.where(np_view_zen == 0)
@@ -144,15 +144,16 @@ def viewzen_corr(data, view_zen):
 
     y, x = np.ma.where((np_view_zen > 0) & (np_view_zen < 90) & (~np_data.mask))
     np_data[y, x] += tau(np_data[y, x]) * delta(np_view_zen[y, x])
-            
-    LOG.debug( 'Calculated data min/avr/max: {:.3f}/{:.3f}/{:.3f}'.format(np.nanmin(np_data),  \
-                                                                          np.nanmean(np_data), \
-                                                                          np.nanmax(np_data)))
-                                              
+
+    LOG.debug('Calculated data min/avr/max: {:.3f}/{:.3f}/{:.3f}'.format(np.nanmin(np_data),
+                                                                         np.nanmean(np_data),
+                                                                         np.nanmax(np_data)))
+
     # back conversion from numpy array into dask array
-    # return data                                              
+    # return data
     return da.from_array(np_data)
-    
+
+
 if __name__ == "__main__":
     this = AtmosphericalCorrection('Suomi-NPP', 'viirs')
     SHAPE = (1000, 3000)
@@ -160,4 +161,3 @@ if __name__ == "__main__":
     SATZ = np.ma.arange(NDIM).reshape(SHAPE) * 60. / float(NDIM)
     TBS = np.ma.arange(NDIM).reshape(SHAPE) * 80.0 / float(NDIM) + 220.
     atm_corr = this.get_correction(da.from_array(SATZ), 'M4', da.from_array(TBS))
-

--- a/pyspectral/atm_correction_ir.py
+++ b/pyspectral/atm_correction_ir.py
@@ -61,10 +61,8 @@ from this time are not longer at DWD.'
 import numpy as np
 try:
     import dask.array as da
-    HAVE_DASK = True
 except ImportError:
     da = None
-    HAVE_DASK = False
 
 
 import logging
@@ -138,7 +136,7 @@ def viewzen_corr(data, view_zen):
 
     is_dask_data = hasattr(data, 'compute') or hasattr(view_zen, 'compute')
 
-    if is_dask_data and HAVE_DASK:
+    if is_dask_data:
         data_tau0 = data + tau0(data)
         data_tau_delta = data + (tau(data) * delta(view_zen))
         dask_data = da.where(view_zen == 0, data_tau0,

--- a/pyspectral/atm_correction_ir.py
+++ b/pyspectral/atm_correction_ir.py
@@ -143,13 +143,13 @@ def viewzen_corr(data, view_zen):
                              da.where((view_zen > 0) & (view_zen < 90),
                                       data_tau_delta, data))
         return dask_data
-    else:
-        y0, x0 = np.ma.where(view_zen == 0)
-        data[y0, x0] += tau0(data[y0, x0])
+    # expect numpy types otherwise
+    y0, x0 = np.ma.where(view_zen == 0)
+    data[y0, x0] += tau0(data[y0, x0])
 
-        y, x = np.ma.where((view_zen > 0) & (view_zen < 90) & (~data.mask))
-        data[y, x] += tau(data[y, x]) * delta(view_zen[y, x])
-        return data
+    y, x = np.ma.where((view_zen > 0) & (view_zen < 90) & (~data.mask))
+    data[y, x] += tau(data[y, x]) * delta(view_zen[y, x])
+    return data
 
 
 if __name__ == "__main__":

--- a/pyspectral/atm_correction_ir.py
+++ b/pyspectral/atm_correction_ir.py
@@ -139,17 +139,10 @@ def viewzen_corr(data, view_zen):
     LOG.debug("Update to process dask array data.") 
     np_view_zen = np.array(view_zen.compute())
     np_data = np.ma.masked_array(data.compute())
-    
-    #y0, x0 = np.ma.where(view_zen == 0)
     y0, x0 = np.ma.where(np_view_zen == 0)
-        
-    # data[y0, x0] += tau0(data[y0, x0])
     np_data[y0, x0] += tau0(np_data[y0, x0])
-    
-    # y, x = np.ma.where((view_zen > 0) & (view_zen < 90) & (~data.mask))
+
     y, x = np.ma.where((np_view_zen > 0) & (np_view_zen < 90) & (~np_data.mask))
-    
-    # data[y, x] += tau(data[y, x]) * delta(view_zen[y, x])
     np_data[y, x] += tau(np_data[y, x]) * delta(np_view_zen[y, x])
             
     LOG.debug( 'Calculated data min/avr/max: {:.3f}/{:.3f}/{:.3f}'.format(np.nanmin(np_data),  \

--- a/pyspectral/tests/test_atm_correction_ir.py
+++ b/pyspectral/tests/test_atm_correction_ir.py
@@ -120,7 +120,13 @@ class TestAtmCorrection(unittest.TestCase):
     """Class for testing pyspectral.atm_correction_ir."""
 
     def test_get_correction(self):
-        """Test getting the atm correction."""
+        """Test getting the atm correction (dask data)."""
         this = AtmosphericalCorrection('EOS-Terra', 'modis')
         atm_corr = this.get_correction(da.from_array(SATZ), None, da.from_array(TBS))
+        np.testing.assert_almost_equal(RES, atm_corr)
+
+    def test_get_correction_np(self):
+        """Test getting the atm correction (numpy data)."""
+        this = AtmosphericalCorrection('EOS-Terra', 'modis')
+        atm_corr = this.get_correction(SATZ, None, TBS)
         np.testing.assert_almost_equal(RES, atm_corr)

--- a/pyspectral/tests/test_atm_correction_ir.py
+++ b/pyspectral/tests/test_atm_correction_ir.py
@@ -24,6 +24,7 @@
 
 
 import numpy as np
+import dask.array as da
 from pyspectral.atm_correction_ir import AtmosphericalCorrection
 import sys
 if sys.version_info < (2, 7):
@@ -121,5 +122,5 @@ class TestAtmCorrection(unittest.TestCase):
     def test_get_correction(self):
         """Test getting the atm correction."""
         this = AtmosphericalCorrection('EOS-Terra', 'modis')
-        atm_corr = this.get_correction(SATZ, None, TBS)
+        atm_corr = this.get_correction(da.from_array(SATZ), None, da.from_array(TBS))
         np.testing.assert_almost_equal(RES, atm_corr)


### PR DESCRIPTION
The IR atmospherical correction algorithm used by DWD is not compatible with dask arrays. Since dask is used already for some time by satpy, it has to be fixed. 
The provided fix is already used by the German weather service (DWD). Would be great if this could be merged to the upstream repo.

 - [x] Tests ~~added~~ modified <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->

