### PR TITLE
Fix so reflectances can be derived from scalar inputs

### DIFF
--- a/doc/seviri_example.rst
+++ b/doc/seviri_example.rst
@@ -10,7 +10,7 @@ Let us try calculate the 3.9 micron reflectance for Meteosat-10:
   >>> tb4 = 282.0
   >>> from pyspectral.near_infrared_reflectance import Calculator
   >>> refl39 = Calculator('Meteosat-10', 'seviri', 'IR3.9')
-  >>> print('%4.3f' %refl39.reflectance_from_tbs(sunz, tb3, tb4))
+  >>> print('{refl:4.3f}'.format(refl=refl39.reflectance_from_tbs(sunz, tb3, tb4)[0]))
   0.555
 
 You can also provide the in-band solar flux from outside when calculating the
@@ -22,12 +22,12 @@ reflectance, saving a few milliseconds per call::
   >>> seviri = RelativeSpectralResponse('Meteosat-10', 'seviri')
   >>> sflux = solar_irr.inband_solarflux(seviri.rsr['IR3.9'])
   >>> refl39 = Calculator('Meteosat-10', 'seviri', 'IR3.9', solar_flux=sflux)
-  >>> print('%4.3f' %refl39.reflectance_from_tbs(sunz, tb3, tb4))
+  >>> print('{refl:4.3f}'.format(refl=refl39.reflectance_from_tbs(sunz, tb3, tb4)[0]))
   0.555
 
 By default the data are masked outside the default Sun zenith-angle (SZA) correction limit (85.0 degrees).
 The masking can be adjusted via `masking_limit` keyword argument to `Calculator`, and turned of by
-defining `Calculator(..., masking_limit=None)`.  The SZA limit can be adjusted via `sunz_threshold` keyword argument:
+defining `Calculator(..., masking_limit=None)`. The SZA limit can be adjusted via `sunz_threshold` keyword argument:
 `Calculator(..., sunz_threshold=88.0)`.
 
 Integration with SatPy

--- a/pyspectral/near_infrared_reflectance.py
+++ b/pyspectral/near_infrared_reflectance.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2014-2020 Pytroll developers
+# Copyright (c) 2014-2021 Pytroll developers
 #
 # Author(s):
 #
@@ -219,15 +219,9 @@ class Calculator(RadTbConverter):
         else:
             is_masked = False
 
-        if np.isscalar(tb_near_ir):
-            tb_nir = array([tb_near_ir, ])
-        else:
-            tb_nir = asanyarray(tb_near_ir)
-
-        if np.isscalar(tb_thermal):
-            tb_therm = array([tb_thermal, ])
-        else:
-            tb_therm = asanyarray(tb_thermal)
+        tb_nir = get_as_array(tb_near_ir)
+        tb_therm = get_as_array(tb_thermal)
+        sun_zenith = get_as_array(sun_zenith)
 
         if tb_therm.shape != tb_nir.shape:
             errmsg = 'Dimensions do not match! {0} and {1}'.format(
@@ -266,6 +260,7 @@ class Calculator(RadTbConverter):
             LOG.info('l_nir = %s', str(l_nir))
 
         LOG.debug("Apply sun-zenith angle clipping between 0 and %5.2f", self.masking_limit)
+
         sunz = sun_zenith.clip(0, self.sunz_threshold)
         mu0 = np.cos(np.deg2rad(sunz))
 
@@ -303,3 +298,14 @@ class Calculator(RadTbConverter):
         if is_masked:
             res = np.ma.masked_invalid(res)
         return res
+
+
+def get_as_array(parameter):
+    """Return parameter as a Dask or Numpy array. 
+
+    Parameter may be a scalar, a list or a Numpy/Dask array.
+    """
+    if np.isscalar(parameter):
+        return array([parameter, ])
+    else:
+        return asanyarray(parameter)

--- a/pyspectral/near_infrared_reflectance.py
+++ b/pyspectral/near_infrared_reflectance.py
@@ -300,12 +300,12 @@ class Calculator(RadTbConverter):
         return res
 
 
-def get_as_array(parameter):
-    """Return parameter as a Dask or Numpy array. 
+def get_as_array(variable):
+    """Return variable as a Dask or Numpy array. 
 
-    Parameter may be a scalar, a list or a Numpy/Dask array.
+    Variable may be a scalar, a list or a Numpy/Dask array.
     """
-    if np.isscalar(parameter):
-        return array([parameter, ])
+    if np.isscalar(variable):
+        return array([variable, ])
     else:
-        return asanyarray(parameter)
+        return asanyarray(variable)

--- a/pyspectral/near_infrared_reflectance.py
+++ b/pyspectral/near_infrared_reflectance.py
@@ -30,6 +30,7 @@ window channel (usually around 11-12 microns).
 """
 
 import os
+import logging
 import numpy as np
 try:
     from dask.array import where, logical_or, asanyarray, array, isnan
@@ -43,7 +44,7 @@ from pyspectral.utils import TB2RAD_DIR
 from pyspectral.utils import WAVE_LENGTH
 from pyspectral.radiance_tb_conversion import RadTbConverter
 from pyspectral.config import get_config
-import logging
+
 LOG = logging.getLogger(__name__)
 
 EPSILON = 0.005
@@ -236,10 +237,7 @@ class Calculator(RadTbConverter):
             tbco2 = None
         else:
             co2corr = True
-            if np.isscalar(tb_ir_co2):
-                tbco2 = array([tb_ir_co2, ])
-            else:
-                tbco2 = asanyarray(tb_ir_co2)
+            tbco2 = get_as_array(tb_ir_co2)
 
         if not self.rsr:
             raise NotImplementedError("Reflectance calculations without "

--- a/pyspectral/near_infrared_reflectance.py
+++ b/pyspectral/near_infrared_reflectance.py
@@ -304,6 +304,6 @@ def get_as_array(variable):
     Variable may be a scalar, a list or a Numpy/Dask array.
     """
     if np.isscalar(variable):
-        return array([variable, ])
+        return asanyarray([variable, ])
 
     return asanyarray(variable)

--- a/pyspectral/near_infrared_reflectance.py
+++ b/pyspectral/near_infrared_reflectance.py
@@ -301,11 +301,11 @@ class Calculator(RadTbConverter):
 
 
 def get_as_array(variable):
-    """Return variable as a Dask or Numpy array. 
+    """Return variable as a Dask or Numpy array.
 
     Variable may be a scalar, a list or a Numpy/Dask array.
     """
     if np.isscalar(variable):
         return array([variable, ])
-    else:
-        return asanyarray(variable)
+
+    return asanyarray(variable)

--- a/pyspectral/tests/test_reflectance.py
+++ b/pyspectral/tests/test_reflectance.py
@@ -227,8 +227,19 @@ def test_get_as_array_from_scalar_input_dask():
         assert res[0] == 2.3
 
 
-def test_get_as_array_from_numpy_array_input():
-    """Test the function to return an array when input is a numpy array."""
+def test_get_as_array_from_scalar_input_numpy():
+    """Test the function to return an array when input is a scalar - using Numpy"""
+    from pyspectral.near_infrared_reflectance import get_as_array
+    import numpy as np
+
+    with patch('pyspectral.near_infrared_reflectance.asanyarray', new=np.asanyarray):
+        res = get_as_array(2.3)
+
+    assert res[0] == 2.3
+
+
+def test_get_as_array_from_numpy_array_input_dask():
+    """Test the function to return an array when input is a numpy array - using Dask"""
     from pyspectral.near_infrared_reflectance import get_as_array
 
     res = get_as_array(np.array([1.0, 2.0]))
@@ -239,8 +250,18 @@ def test_get_as_array_from_numpy_array_input():
         np.testing.assert_allclose(res, np.array([1.0, 2.0]), 5)
 
 
-def test_get_as_array_from_list_input():
-    """Test the function to return an array when input is a list."""
+def test_get_as_array_from_numpy_array_input_numpy():
+    """Test the function to return an array when input is a numpy array - using Numpy"""
+    from pyspectral.near_infrared_reflectance import get_as_array
+
+    with patch('pyspectral.near_infrared_reflectance.asanyarray', new=np.asanyarray):
+        res = get_as_array(np.array([1.0, 2.0]))
+
+    np.testing.assert_allclose(res, np.array([1.0, 2.0]), 5)
+
+
+def test_get_as_array_from_list_input_dask():
+    """Test the function to return an array when input is a list - using Dask"""
     from pyspectral.near_infrared_reflectance import get_as_array
 
     res = get_as_array([1.0, 2.0])
@@ -249,3 +270,13 @@ def test_get_as_array_from_list_input():
         np.testing.assert_allclose(res.compute(), np.array([1.0, 2.0]), 5)
     else:
         np.testing.assert_allclose(res, np.array([1.0, 2.0]), 5)
+
+
+def test_get_as_array_from_list_input_numpy():
+    """Test the function to return an array when input is a list - using Numpy"""
+    from pyspectral.near_infrared_reflectance import get_as_array
+
+    with patch('pyspectral.near_infrared_reflectance.asanyarray', new=np.asanyarray):
+        res = get_as_array([1.1, 2.2])
+
+    np.testing.assert_allclose(res, np.array([1.1, 2.2]), 5)

--- a/pyspectral/tests/test_reflectance.py
+++ b/pyspectral/tests/test_reflectance.py
@@ -26,7 +26,6 @@ import numpy as np
 import unittest
 from unittest.mock import patch
 from pyspectral.near_infrared_reflectance import Calculator, TERMINATOR_LIMIT
-from pyspectral.near_infrared_reflectance import get_as_array
 
 
 TEST_RSR = {'20': {},
@@ -217,18 +216,21 @@ class TestReflectance(unittest.TestCase):
             pass
 
 
-def test_get_as_array_from_scalar_input():
-    """Test the function to return an array when input is a scalar"""
-    res = get_as_array(1)
+def test_get_as_array_from_scalar_input_dask():
+    """Test the function to return an array when input is a scalar - using Dask"""
+    from pyspectral.near_infrared_reflectance import get_as_array
 
+    res = get_as_array(2.3)
     if hasattr(res, 'compute'):
-        assert res.compute()[0] == 1
+        assert res.compute()[0] == 2.3
     else:
-        assert res[0] == 1
+        assert res[0] == 2.3
 
 
 def test_get_as_array_from_numpy_array_input():
     """Test the function to return an array when input is a numpy array."""
+    from pyspectral.near_infrared_reflectance import get_as_array
+
     res = get_as_array(np.array([1.0, 2.0]))
 
     if hasattr(res, 'compute'):
@@ -239,6 +241,8 @@ def test_get_as_array_from_numpy_array_input():
 
 def test_get_as_array_from_list_input():
     """Test the function to return an array when input is a list."""
+    from pyspectral.near_infrared_reflectance import get_as_array
+
     res = get_as_array([1.0, 2.0])
 
     if hasattr(res, 'compute'):

--- a/pyspectral/tests/test_reflectance.py
+++ b/pyspectral/tests/test_reflectance.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2013-2020 Pytroll developers
+# Copyright (c) 2013-2021 Pytroll developers
 #
 # Author(s):
 #
@@ -22,17 +22,11 @@
 
 """Unit testing the 3.7 micron reflectance calculations."""
 
-from pyspectral.near_infrared_reflectance import Calculator, TERMINATOR_LIMIT
 import numpy as np
-import sys
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
-if sys.version_info < (3,):
-    from mock import patch
-else:
-    from unittest.mock import patch
+import unittest
+from unittest.mock import patch
+from pyspectral.near_infrared_reflectance import Calculator, TERMINATOR_LIMIT
+from pyspectral.near_infrared_reflectance import get_as_array
 
 
 TEST_RSR = {'20': {},
@@ -164,15 +158,15 @@ class TestReflectance(unittest.TestCase):
             self.assertAlmostEqual(refl37_sz88.bandwavelength, 3.780282, 5)
             self.assertEqual(refl37_sz88.bandname, '20')
 
-        sunz = np.array([80.])
-        tb3 = np.array([290.])
-        tb4 = np.array([282.])
+        sunz = 80.
+        tb3 = 290.
+        tb4 = 282.
         refl = refl37.reflectance_from_tbs(sunz, tb3, tb4)
         np.testing.assert_allclose(refl[0], 0.251245010648, 6)
 
-        sunz = np.array([85.])
-        tb3 = np.array([290.])
-        tb4 = np.array([282.])
+        sunz = 85.
+        tb3 = 290.
+        tb4 = 282.
         refl = refl37.reflectance_from_tbs(sunz, tb3, tb4)
         np.testing.assert_allclose(refl[0], 1.12236884, 6)
 
@@ -221,3 +215,33 @@ class TestReflectance(unittest.TestCase):
             self.assertTrue(hasattr(refl, 'compute'))
         except ImportError:
             pass
+
+
+def test_get_as_array_from_scalar_input():
+    """Test the function to return an array when input is a scalar"""
+    res = get_as_array(1)
+
+    if hasattr(res, 'compute'):
+        assert res.compute()[0] == 1
+    else:
+        assert res[0] == 1
+
+
+def test_get_as_array_from_numpy_array_input():
+    """Test the function to return an array when input is a numpy array."""
+    res = get_as_array(np.array([1.0, 2.0]))
+
+    if hasattr(res, 'compute'):
+        np.testing.assert_allclose(res.compute(), np.array([1.0, 2.0]), 5)
+    else:
+        np.testing.assert_allclose(res, np.array([1.0, 2.0]), 5)
+
+
+def test_get_as_array_from_list_input():
+    """Test the function to return an array when input is a list."""
+    res = get_as_array([1.0, 2.0])
+
+    if hasattr(res, 'compute'):
+        np.testing.assert_allclose(res.compute(), np.array([1.0, 2.0]), 5)
+    else:
+        np.testing.assert_allclose(res, np.array([1.0, 2.0]), 5)

--- a/rsr_convert_scripts/aatsr_reader.py
+++ b/rsr_convert_scripts/aatsr_reader.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2016, 2017 Pytroll developers
+# Copyright (c) 2016, 2017, 2021 Pytroll developers
 #
 # Author(s):
 #
@@ -79,9 +79,13 @@ class AatsrRSR(object):
 
 
 def main():
-    """Main"""
+    """Main.
+
+    """
 
     tohdf5(AatsrRSR, 'Envisat', AATSR_BAND_NAMES)
 
+
 if __name__ == "__main__":
+
     main()

--- a/rsr_convert_scripts/ahi_reader.py
+++ b/rsr_convert_scripts/ahi_reader.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2015-2017 Pytroll developers
+# Copyright (c) 2015-2017, 2021 Pytroll developers
 #
 # Author(s):
 #
@@ -26,8 +26,6 @@ http://www.data.jma.go.jp/mscweb/en/himawari89/space_segment/spsg_ahi.html#srf
 """
 
 import logging
-LOG = logging.getLogger(__name__)
-
 import os
 import numpy as np
 from xlrd import open_workbook
@@ -35,6 +33,7 @@ from xlrd import open_workbook
 from pyspectral.utils import get_central_wave
 from pyspectral.config import get_config
 
+LOG = logging.getLogger(__name__)
 
 AHI_BAND_NAMES = {'Band 1': 'ch1',
                   'Band 2': 'ch2',
@@ -148,6 +147,7 @@ def main():
     for satnum in [8, 9]:
         convert2hdf5('Himawari-{0:d}'.format(satnum))
         print("Himawari-{0:d} done...".format(satnum))
+
 
 if __name__ == "__main__":
 

--- a/rsr_convert_scripts/cocts_rsr.py
+++ b/rsr_convert_scripts/cocts_rsr.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019 Pytroll developers
+# Copyright (c) 2019, 2021 Pytroll developers
 #
 # Author(s):
 #
@@ -20,12 +20,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Read the HY-1C COCTS relative spectral responses. Data from 
+"""Read the HY-1C COCTS relative spectral responses. Data from
 lwk1542@hotmail.com
 
 NB! The two IR bands are NOT included.
 
-See issue 
+See issue
 https://github.com/pytroll/pyspectral/issues/61
 """
 import os


### PR DESCRIPTION
Fix so reflectances can be derived from scalar inputs (including sun zenith)

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
