### PR TITLE
Refactor rayleigh correction to be more dask friendly

### DIFF
--- a/pyspectral/config.py
+++ b/pyspectral/config.py
@@ -87,5 +87,7 @@ def get_config():
     user_datadir = app_dirs.user_data_dir
     config['rsr_dir'] = expanduser(config.get('rsr_dir', user_datadir))
     config['rayleigh_dir'] = expanduser(config.get('rayleigh_dir', user_datadir))
+    os.makedirs(config['rsr_dir'], exist_ok=True)
+    os.makedirs(config['rayleigh_dir'], exist_ok=True)
 
     return config

--- a/pyspectral/near_infrared_reflectance.py
+++ b/pyspectral/near_infrared_reflectance.py
@@ -40,7 +40,7 @@ except ImportError:
 from pyspectral.solar import (SolarIrradianceSpectrum,
                               TOTAL_IRRADIANCE_SPECTRUM_2000ASTM)
 from pyspectral.utils import BANDNAMES, get_bandname_from_wavelength
-from pyspectral.utils import get_tb2rad_dir
+from pyspectral.utils import _get_tb2rad_dir
 from pyspectral.utils import WAVE_LENGTH
 from pyspectral.radiance_tb_conversion import RadTbConverter
 from pyspectral.config import get_config
@@ -108,7 +108,7 @@ class Calculator(RadTbConverter):
         self.lutfile = None
 
         platform_sensor = platform_name + '-' + instrument
-        tb2rad_dir = get_tb2rad_dir()
+        tb2rad_dir = _get_tb2rad_dir()
         if platform_sensor in options and 'tb2rad_lut_filename' in options[platform_sensor]:
             if isinstance(options[platform_sensor]['tb2rad_lut_filename'], dict):
                 for item in options[platform_sensor]['tb2rad_lut_filename']:

--- a/pyspectral/near_infrared_reflectance.py
+++ b/pyspectral/near_infrared_reflectance.py
@@ -40,7 +40,7 @@ except ImportError:
 from pyspectral.solar import (SolarIrradianceSpectrum,
                               TOTAL_IRRADIANCE_SPECTRUM_2000ASTM)
 from pyspectral.utils import BANDNAMES, get_bandname_from_wavelength
-from pyspectral.utils import TB2RAD_DIR
+from pyspectral.utils import get_tb2rad_dir
 from pyspectral.utils import WAVE_LENGTH
 from pyspectral.radiance_tb_conversion import RadTbConverter
 from pyspectral.config import get_config
@@ -108,6 +108,7 @@ class Calculator(RadTbConverter):
         self.lutfile = None
 
         platform_sensor = platform_name + '-' + instrument
+        tb2rad_dir = get_tb2rad_dir()
         if platform_sensor in options and 'tb2rad_lut_filename' in options[platform_sensor]:
             if isinstance(options[platform_sensor]['tb2rad_lut_filename'], dict):
                 for item in options[platform_sensor]['tb2rad_lut_filename']:
@@ -126,14 +127,14 @@ class Calculator(RadTbConverter):
             if self.lutfile and not os.path.exists(os.path.dirname(self.lutfile)):
                 LOG.warning(
                     "Directory %s does not exist! Check config file", os.path.dirname(self.lutfile))
-                self.lutfile = os.path.join(TB2RAD_DIR, os.path.basename(self.lutfile))
+                self.lutfile = os.path.join(tb2rad_dir, os.path.basename(self.lutfile))
 
         if self.lutfile is None:
             LOG.info("No lut filename available in config file. "
                      "Will generate filename automatically")
             lutname = 'tb2rad_lut_{0}_{1}_{band}'.format(
                 self.platform_name.lower(), self.instrument.lower(), band=self.bandname.lower())
-            self.lutfile = os.path.join(TB2RAD_DIR, lutname + '.npz')
+            self.lutfile = os.path.join(tb2rad_dir, lutname + '.npz')
 
         LOG.info("lut filename: " + str(self.lutfile))
         if not os.path.exists(self.lutfile):

--- a/pyspectral/near_infrared_reflectance.py
+++ b/pyspectral/near_infrared_reflectance.py
@@ -31,6 +31,7 @@ window channel (usually around 11-12 microns).
 
 import os
 import logging
+import tempfile
 import numpy as np
 try:
     from dask.array import where, logical_or, asanyarray, isnan
@@ -40,7 +41,6 @@ except ImportError:
 from pyspectral.solar import (SolarIrradianceSpectrum,
                               TOTAL_IRRADIANCE_SPECTRUM_2000ASTM)
 from pyspectral.utils import BANDNAMES, get_bandname_from_wavelength
-from pyspectral.utils import _get_tb2rad_dir
 from pyspectral.utils import WAVE_LENGTH
 from pyspectral.radiance_tb_conversion import RadTbConverter
 from pyspectral.config import get_config
@@ -108,7 +108,7 @@ class Calculator(RadTbConverter):
         self.lutfile = None
 
         platform_sensor = platform_name + '-' + instrument
-        tb2rad_dir = _get_tb2rad_dir()
+        tb2rad_dir = options.get('tb2rad_dir', tempfile.gettempdir())
         if platform_sensor in options and 'tb2rad_lut_filename' in options[platform_sensor]:
             if isinstance(options[platform_sensor]['tb2rad_lut_filename'], dict):
                 for item in options[platform_sensor]['tb2rad_lut_filename']:

--- a/pyspectral/rayleigh.py
+++ b/pyspectral/rayleigh.py
@@ -49,7 +49,7 @@ except ImportError:
 
 from geotiepoints.multilinear import MultilinearInterpolator
 from pyspectral.rsr_reader import RelativeSpectralResponse
-from pyspectral.utils import (INSTRUMENTS, RAYLEIGH_LUT_DIRS,
+from pyspectral.utils import (INSTRUMENTS, get_rayleigh_lut_dir,
                               AEROSOL_TYPES, ATMOSPHERES,
                               BANDNAMES,
                               ATM_CORRECTION_LUT_VERSION,
@@ -88,11 +88,8 @@ class RayleighConfigBaseClass(object):
     def __init__(self, aerosol_type, atm_type='us-standard'):
         """Initialize class and determine LUT to use."""
         options = get_config()
-        self.do_download = False
+        self.do_download = 'download_from_internet' in options and options['download_from_internet']
         self._lutfiles_version_uptodate = False
-
-        if 'download_from_internet' in options and options['download_from_internet']:
-            self.do_download = True
 
         if atm_type not in ATMOSPHERES:
             raise AttributeError('Atmosphere type not supported! ' +
@@ -113,14 +110,13 @@ class RayleighConfigBaseClass(object):
             self.lutfiles_version_uptodate = True
 
     def _get_lutfiles_version(self):
-        """
-        Get LUT file version.
+        """Get LUT file version.
 
         Check the version of the atm correction luts from the version file in the
         specific aerosol correction directory.
 
         """
-        basedir = RAYLEIGH_LUT_DIRS[self._aerosol_type]
+        basedir = get_rayleigh_lut_dir(self._aerosol_type)
         lutfiles_version_path = os.path.join(basedir,
                                              ATM_CORRECTION_LUT_VERSION[self._aerosol_type]['filename'])
 
@@ -171,8 +167,7 @@ class Rayleigh(RayleighConfigBaseClass):
 
         self.sensor = sensor.replace('/', '')
 
-        rayleigh_dir = RAYLEIGH_LUT_DIRS[aerosol_type]
-
+        rayleigh_dir = get_rayleigh_lut_dir(aerosol_type)
         ext = atm_type.replace(' ', '_')
         lutname = "rayleigh_lut_{0}.h5".format(ext)
         self.reflectance_lut_filename = os.path.join(rayleigh_dir, lutname)

--- a/pyspectral/rayleigh.py
+++ b/pyspectral/rayleigh.py
@@ -323,8 +323,8 @@ def _get_wavelength_adjusted_lut_rayleigh_reflectance(lut_filename, wvl):
     if not wvl_coord.min() < wvl < wvl_coord.max():
         return None
     wavelength_index, wavelength_factor = _get_wavelength_index_and_factor(wvl_coord, wvl)
-    raylwvl = wavelength_factor * rayleigh_refl[wavelength_index - 1, :, :, :] + \
-              (1 - wavelength_factor) * rayleigh_refl[wavelength_index, :, :, :]
+    raylwvl = (wavelength_factor * rayleigh_refl[wavelength_index - 1, :, :, :] +
+               (1 - wavelength_factor) * rayleigh_refl[wavelength_index, :, :, :])
     return raylwvl
 
 

--- a/pyspectral/rayleigh.py
+++ b/pyspectral/rayleigh.py
@@ -267,9 +267,10 @@ class Rayleigh(RayleighConfigBaseClass):
             LOG.warning("Effective wavelength for band %s outside 400-800 nm range!",
                         str(bandname))
             LOG.info("Setting the rayleigh/aerosol reflectance contribution to zero!")
+            chunks = getattr(sun_zenith, "chunks", None) if redband is None else getattr(redband, "chunks", None)
             return _get_zeroed_result(
                 sun_zenith.shape, compute,
-                chunks=sun_zenith.chunks if redband is None else redband.chunks)
+                chunks=chunks)
         res = map_blocks(self._interp_rayleigh_refl_by_angles,
                          sun_zenith, sat_zenith, azidiff, rayleigh_refl,
                          self.reflectance_lut_filename,

--- a/pyspectral/rayleigh.py
+++ b/pyspectral/rayleigh.py
@@ -25,6 +25,7 @@
 
 import os
 import logging
+import numbers
 
 import h5py
 import numpy as np
@@ -36,7 +37,7 @@ except ImportError:
 
 from geotiepoints.multilinear import MultilinearInterpolator
 from pyspectral.rsr_reader import RelativeSpectralResponse
-from pyspectral.utils import (INSTRUMENTS, _get_rayleigh_lut_dir,
+from pyspectral.utils import (INSTRUMENTS, get_rayleigh_lut_dir,
                               AEROSOL_TYPES, ATMOSPHERES,
                               BANDNAMES,
                               ATM_CORRECTION_LUT_VERSION,
@@ -105,7 +106,7 @@ class RayleighConfigBaseClass(object):
         specific aerosol correction directory.
 
         """
-        basedir = _get_rayleigh_lut_dir(self._aerosol_type)
+        basedir = get_rayleigh_lut_dir(self._aerosol_type)
         lutfiles_version_path = os.path.join(basedir,
                                              ATM_CORRECTION_LUT_VERSION[self._aerosol_type]['filename'])
 
@@ -156,7 +157,7 @@ class Rayleigh(RayleighConfigBaseClass):
 
         self.sensor = sensor.replace('/', '')
 
-        rayleigh_dir = _get_rayleigh_lut_dir(aerosol_type)
+        rayleigh_dir = get_rayleigh_lut_dir(aerosol_type)
         ext = atm_type.replace(' ', '_')
         lutname = "rayleigh_lut_{0}.h5".format(ext)
         self.reflectance_lut_filename = os.path.join(rayleigh_dir, lutname)
@@ -190,7 +191,7 @@ class Rayleigh(RayleighConfigBaseClass):
 
         """
         # Get wavelength in nm for band:
-        if isinstance(band_name_or_wavelength, (float, int)):
+        if isinstance(band_name_or_wavelength, numbers.Real):
             LOG.warning('A wavelength is provided instead of band name - ' +
                         'disregard the relative spectral responses and assume ' +
                         'it is the effective wavelength: %f (micro meter)', band_name_or_wavelength)

--- a/pyspectral/rayleigh.py
+++ b/pyspectral/rayleigh.py
@@ -40,7 +40,7 @@ except ImportError:
     HAVE_DASK = False
 
     def map_blocks(func, *args, **kwargs):
-        """Placeholder for dask's map_blocks since it isn't available."""
+        """Mimic dask's map_blocks for a single call since it isn't available."""
         kwargs.pop("meta", None)
         kwargs.pop("dtype", None)
         kwargs.pop("chunks", None)
@@ -49,7 +49,7 @@ except ImportError:
 
 from geotiepoints.multilinear import MultilinearInterpolator
 from pyspectral.rsr_reader import RelativeSpectralResponse
-from pyspectral.utils import (INSTRUMENTS, get_rayleigh_lut_dir,
+from pyspectral.utils import (INSTRUMENTS, _get_rayleigh_lut_dir,
                               AEROSOL_TYPES, ATMOSPHERES,
                               BANDNAMES,
                               ATM_CORRECTION_LUT_VERSION,
@@ -116,7 +116,7 @@ class RayleighConfigBaseClass(object):
         specific aerosol correction directory.
 
         """
-        basedir = get_rayleigh_lut_dir(self._aerosol_type)
+        basedir = _get_rayleigh_lut_dir(self._aerosol_type)
         lutfiles_version_path = os.path.join(basedir,
                                              ATM_CORRECTION_LUT_VERSION[self._aerosol_type]['filename'])
 
@@ -167,7 +167,7 @@ class Rayleigh(RayleighConfigBaseClass):
 
         self.sensor = sensor.replace('/', '')
 
-        rayleigh_dir = get_rayleigh_lut_dir(aerosol_type)
+        rayleigh_dir = _get_rayleigh_lut_dir(aerosol_type)
         ext = atm_type.replace(' ', '_')
         lutname = "rayleigh_lut_{0}.h5".format(ext)
         self.reflectance_lut_filename = os.path.join(rayleigh_dir, lutname)
@@ -294,6 +294,7 @@ class Rayleigh(RayleighConfigBaseClass):
     @staticmethod
     def reduce_rayleigh_highzenith(zenith, rayref, thresh_zen, maxzen, strength):
         """Reduce the Rayleigh correction amount at high zenith angles.
+
         This linearly scales the Rayleigh reflectance, `rayref`, for solar or satellite zenith angles, `zenith`,
         above a threshold angle, `thresh_zen`. Between `thresh_zen` and `maxzen` the Rayleigh reflectance will
         be linearly scaled, from one at `thresh_zen` to zero at `maxzen`.

--- a/pyspectral/rayleigh.py
+++ b/pyspectral/rayleigh.py
@@ -31,10 +31,8 @@ import numpy as np
 
 try:
     import dask.array as da
-    HAVE_DASK = True
 except ImportError:
     da = None
-    HAVE_DASK = False
 
 from geotiepoints.multilinear import MultilinearInterpolator
 from pyspectral.rsr_reader import RelativeSpectralResponse
@@ -50,7 +48,7 @@ LOG = logging.getLogger(__name__)
 
 def _map_blocks_or_direct_call(func, *args, **kwargs):
     """Call dask's map_blocks or call func directly if dask is not available."""
-    if not HAVE_DASK:
+    if da is None:
         kwargs.pop("meta", None)
         kwargs.pop("dtype", None)
         kwargs.pop("chunks", None)
@@ -240,7 +238,7 @@ class Rayleigh(RayleighConfigBaseClass):
         """Get the reflectance from the three sun-sat angles."""
         # if the user gave us non-dask arrays we'll use the dask
         # version of the algorithm but return numpy arrays back
-        compute = HAVE_DASK and not isinstance(sun_zenith, da.Array)
+        compute = da is not None and not isinstance(sun_zenith, da.Array)
 
         wvl, band_name = self._get_effective_wavelength_and_band_name(band_name_or_wavelength)
         try:

--- a/pyspectral/rayleigh.py
+++ b/pyspectral/rayleigh.py
@@ -230,6 +230,9 @@ class Rayleigh(RayleighConfigBaseClass):
         return self._rayl, self._wvl_coord, self._azid_coord,\
             self._satz_sec_coord, self._sunz_sec_coord
 
+    # def _do_interp(sun_zenith, sat_zenith, azidiff, wvl, reflectance_lut_filename):
+    #     lut_vars = get_reflectance_lut(reflectance_lut_filename)
+    #     rayl, wvl_coord, azid_coord, satz_sec_coord, sunz_sec_coord = lut_vars
     @staticmethod
     def _do_interp(minterp, sunzsec, azidiff, satzsec):
         interp_points2 = np.vstack((sunzsec.ravel(), 180 - azidiff.ravel(), satzsec.ravel()))
@@ -309,20 +312,91 @@ class Rayleigh(RayleighConfigBaseClass):
             len(sunz_sec_coord), len(azid_coord), len(satz_sec_coord)]
         f_3d_grid = atleast_2d(raylwvl.ravel())
 
-        if HAVE_DASK and isinstance(smin[0], Array):
-            # compute all of these at the same time before passing to the interpolator
-            # otherwise they are computed separately
-            smin, smax, orders, f_3d_grid = da.compute(smin, smax, orders, f_3d_grid)
         minterp = MultilinearInterpolator(smin, smax, orders)
         minterp.set_values(f_3d_grid)
+        interp_points2 = np.vstack((sunzsec.ravel(), 180 - azidiff.ravel(), satzsec.ravel()))
+        res = minterp(interp_points2)
+        return res.reshape(sunzsec.shape)
+
+    def get_reflectance(self, sun_zenith, sat_zenith, azidiff, bandname, redband=None):
+        """Get the reflectance from the three sun-sat angles."""
+        # Get wavelength in nm for band:
+        if isinstance(bandname, float):
+            LOG.warning('A wavelength is provided instead of band name - ' +
+                        'disregard the relative spectral responses and assume ' +
+                        'it is the effective wavelength: %f (micro meter)', bandname)
+            wvl = bandname * 1000.0
+        else:
+            wvl = self.get_effective_wavelength(bandname)
+            wvl = wvl * 1000.0
+
+        # rayl, wvl_coord, azid_coord, satz_sec_coord, sunz_sec_coord = self.get_reflectance_lut()
+
+        # force dask arrays
+        # compute = False
+        # if HAVE_DASK and not isinstance(sun_zenith, Array):
+        #     compute = True
+        #     sun_zenith = from_array(sun_zenith, chunks=sun_zenith.shape)
+        #     sat_zenith = from_array(sat_zenith, chunks=sat_zenith.shape)
+        #     azidiff = from_array(azidiff, chunks=azidiff.shape)
+        #     if redband is not None:
+        #         redband = from_array(redband, chunks=redband.shape)
+
+        # XXX: Try to optimize/remove rad2deg/deg2rad
+        # clip_angle = rad2deg(arccos(1. / sunz_sec_coord.max()))
+        # sun_zenith = clip(sun_zenith, 0, clip_angle)
+        # sunzsec = 1. / cos(deg2rad(sun_zenith))
+        # clip_angle = rad2deg(arccos(1. / satz_sec_coord.max()))
+        # sat_zenith = clip(sat_zenith, 0, clip_angle)
+        # satzsec = 1. / cos(deg2rad(sat_zenith))
+        # shape = sun_zenith.shape
+
+        # if not(wvl_coord.min() < wvl < wvl_coord.max()):
+        #     LOG.warning(
+        #         "Effective wavelength for band %s outside 400-800 nm range!",
+        #         str(bandname))
+        #     LOG.info(
+        #         "Set the rayleigh/aerosol reflectance contribution to zero!")
+        #     if HAVE_DASK:
+        #         chunks = sun_zenith.chunks if redband is None else redband.chunks
+        #         res = zeros(shape, chunks=chunks)
+        #         return res.compute() if compute else res
+        #
+        #     return zeros(shape)
+        #
+        # idx = np.searchsorted(wvl_coord, wvl)
+        # wvl1 = wvl_coord[idx - 1]
+        # wvl2 = wvl_coord[idx]
+        #
+        # fac = (wvl2 - wvl) / (wvl2 - wvl1)
+        # raylwvl = fac * rayl[idx - 1, :, :, :] + (1 - fac) * rayl[idx, :, :, :]
+        # tic = time.time()
+        #
+        # smin = [sunz_sec_coord[0], azid_coord[0], satz_sec_coord[0]]
+        # smax = [sunz_sec_coord[-1], azid_coord[-1], satz_sec_coord[-1]]
+        # orders = [
+        #     len(sunz_sec_coord), len(azid_coord), len(satz_sec_coord)]
+        # f_3d_grid = atleast_2d(raylwvl.ravel())
+        #
+        # if HAVE_DASK and isinstance(smin[0], Array):
+        #     # compute all of these at the same time before passing to the interpolator
+        #     # otherwise they are computed separately
+        #     smin, smax, orders, f_3d_grid = da.compute(smin, smax, orders, f_3d_grid)
+        # minterp = MultilinearInterpolator(smin, smax, orders)
+        # minterp.set_values(f_3d_grid)
 
         if HAVE_DASK:
-            ipn = map_blocks(self._do_interp, minterp, sunzsec, azidiff,
-                             satzsec, dtype=raylwvl.dtype, chunks=azidiff.chunks)
+            # ipn = map_blocks(self._do_interp, minterp, sunzsec, azidiff,
+            #                  satzsec,
+            #                  meta=np.array((), dtype=raylwvl.dtype),
+            #                  dtype=raylwvl.dtype, chunks=azidiff.chunks)
+            ipn = map_blocks(self._do_interp, sun_zenith, sat_zenith, azidiff, wvl, self.reflectance_lut_filename,
+                             meta=np.array((), dtype=np.float64),
+                             dtype=np.float64, chunks=azidiff.chunks)
         else:
             ipn = self._do_interp(minterp, sunzsec, azidiff, satzsec)
 
-        LOG.debug("Time - Interpolation: {0:f}".format(time.time() - tic))
+        # LOG.debug("Time - Interpolation: {0:f}".format(time.time() - tic))
 
         ipn *= 100
         res = ipn
@@ -366,22 +440,22 @@ def get_reflectance_lut_from_file(filename):
     satellite_zenith_secant = h5f['satellite_zenith_secant']
     sun_zenith_secant = h5f['sun_zenith_secant']
 
-    if HAVE_DASK:
-        tab = from_array(tab, chunks=(10, 10, 10, 10))
-        wvl = wvl[:]  # no benefit to dask-ifying this
-        azidiff = from_array(azidiff, chunks=(1000,))
-        satellite_zenith_secant = from_array(satellite_zenith_secant,
-                                             chunks=(1000,))
-        sun_zenith_secant = from_array(sun_zenith_secant,
-                                       chunks=(1000,))
-    else:
-        # load all of the data we are going to use in to memory
-        tab = tab[:]
-        wvl = wvl[:]
-        azidiff = azidiff[:]
-        satellite_zenith_secant = satellite_zenith_secant[:]
-        sun_zenith_secant = sun_zenith_secant[:]
-        h5f.close()
+    # if HAVE_DASK:
+    #     tab = from_array(tab, chunks=(10, 10, 10, 10))
+    #     wvl = wvl[:]  # no benefit to dask-ifying this
+    #     azidiff = from_array(azidiff, chunks=(1000,))
+    #     satellite_zenith_secant = from_array(satellite_zenith_secant,
+    #                                          chunks=(1000,))
+    #     sun_zenith_secant = from_array(sun_zenith_secant,
+    #                                    chunks=(1000,))
+    # else:
+    # load all of the data we are going to use in to memory
+    tab = tab[:]
+    wvl = wvl[:]
+    azidiff = azidiff[:]
+    satellite_zenith_secant = satellite_zenith_secant[:]
+    sun_zenith_secant = sun_zenith_secant[:]
+    h5f.close()
 
     return tab, wvl, azidiff, satellite_zenith_secant, sun_zenith_secant
 

--- a/pyspectral/tests/data.py
+++ b/pyspectral/tests/data.py
@@ -268,4 +268,4 @@ TEST_RAYLEIGH_LUT = np.array([[[[0.08674087,  0.09136106,  0.09747749,  0.104837
 TEST_RAYLEIGH_AZID_COORD = np.array([100.,  110.,  120.,  130.,  140.,  150.,  160.], dtype='float32')
 TEST_RAYLEIGH_SATZ_COORD = np.array([1.,  1.25,  1.5,  1.75,  2.,  2.25], dtype='float32')
 TEST_RAYLEIGH_SUNZ_COORD = np.array([1.,  1.25,  1.5,  1.75,  2.,  2.25,  2.5,  2.75], dtype='float32')
-TEST_RAYLEIGH_WVL_COORD = np.array([440.,  445.], dtype='float32')
+TEST_RAYLEIGH_WVL_COORD = np.array([631.,  636.], dtype='float32')

--- a/pyspectral/tests/test_rayleigh.py
+++ b/pyspectral/tests/test_rayleigh.py
@@ -96,8 +96,8 @@ def fake_lut_hdf5(tmp_path):
         "rayleigh_dir": str(tmp_path),
         "download_from_internet": False,
     }
-    with (patch('pyspectral.rayleigh.get_config', lambda: fake_config),
-          patch('pyspectral.utils.get_config', lambda: fake_config)):
+    with patch('pyspectral.rayleigh.get_config', lambda: fake_config), \
+            patch('pyspectral.utils.get_config', lambda: fake_config):
         yield lut_filename
 
 
@@ -227,10 +227,10 @@ class TestRayleigh:
 
             this = rayleigh.Rayleigh('Himawari-8', 'ahi')
             with pytest.raises(BandFrequencyOutOfRange):
-                this.get_effective_wavelength(0.9)
+                this._get_effective_wavelength(0.9)
 
             # Only ch3 (~0.63) testdata implemented yet...
-            ewl = this.get_effective_wavelength(0.65)
+            ewl = this._get_effective_wavelength(0.65)
             np.testing.assert_allclose(ewl, 0.6356167)
 
         with patch('pyspectral.rayleigh.RelativeSpectralResponse') as mymock:
@@ -238,11 +238,11 @@ class TestRayleigh:
                 'Fake that there is no spectral response file...')
 
             this = rayleigh.Rayleigh('Himawari-8', 'ahi')
-            ewl = this.get_effective_wavelength(0.7)
+            ewl = this._get_effective_wavelength(0.7)
             assert ewl == 0.7
-            ewl = this.get_effective_wavelength(0.9)
+            ewl = this._get_effective_wavelength(0.9)
             assert ewl == 0.9
-            ewl = this.get_effective_wavelength(0.455)
+            ewl = this._get_effective_wavelength(0.455)
             assert ewl == 0.455
 
     @patch('os.path.exists')

--- a/pyspectral/tests/test_rayleigh.py
+++ b/pyspectral/tests/test_rayleigh.py
@@ -291,7 +291,7 @@ class TestRayleigh:
         retv = rayleigh.Rayleigh.reduce_rayleigh_highzenith(sun_zenith, in_rayleigh, 30., 90., 1.5)
         np.testing.assert_allclose(retv, TEST_RAYLEIGH_RESULT_R2)
 
-    @patch('pyspectral.rayleigh.HAVE_DASK', False)
+    @patch('pyspectral.rayleigh.da', None)
     def test_get_reflectance_redband_outside_clip(self, fake_lut_hdf5):
         """Test getting the reflectance correction - using red band reflections outside 20 to 100."""
         sun_zenith = np.array([67., 32.])
@@ -324,7 +324,7 @@ class TestRayleigh:
         np.testing.assert_allclose(refl_corr1, refl_corr2)
         np.testing.assert_allclose(refl_corr2, refl_corr3)
 
-    @patch('pyspectral.rayleigh.HAVE_DASK', False)
+    @patch('pyspectral.rayleigh.da', None)
     def test_get_reflectance(self, fake_lut_hdf5):
         """Test getting the reflectance correction."""
         sun_zenith = np.array([67., 32.])
@@ -348,7 +348,7 @@ class TestRayleigh:
         assert isinstance(refl_corr, np.ndarray)
         np.testing.assert_allclose(refl_corr, TEST_RAYLEIGH_RESULT2)
 
-    @patch('pyspectral.rayleigh.HAVE_DASK', False)
+    @patch('pyspectral.rayleigh.da', None)
     def test_get_reflectance_no_rsr(self, fake_lut_hdf5):
         """Test getting the reflectance correction, simulating that we have no RSR data."""
         with mocked_rsr() as rsr_obj:
@@ -361,7 +361,7 @@ class TestRayleigh:
             with pytest.raises(KeyError):
                 ufo.get_reflectance(sun_zenith, sat_zenith, azidiff, 'ch3', redband_refl)
 
-    @patch('pyspectral.rayleigh.HAVE_DASK', False)
+    @patch('pyspectral.rayleigh.da', None)
     def test_get_reflectance_float_wavelength(self, fake_lut_hdf5):
         """Test getting the reflectance correction."""
         with mocked_rsr() as rsr_obj:
@@ -379,7 +379,7 @@ class TestRayleigh:
             assert isinstance(refl_corr, np.ndarray)
             assert rsr_obj.not_called()
 
-    @patch('pyspectral.rayleigh.HAVE_DASK', False)
+    @patch('pyspectral.rayleigh.da', None)
     def test_get_reflectance_wvl_outside_range(self, fake_lut_hdf5):
         """Test getting the reflectance correction with wavelength outside correction range."""
         with mocked_rsr() as rsr_obj:

--- a/pyspectral/tests/test_rayleigh.py
+++ b/pyspectral/tests/test_rayleigh.py
@@ -23,9 +23,9 @@
 """Unittest for the rayleigh correction utilities."""
 
 import os
-import sys
 import numpy as np
 import dask.array as da
+import pytest
 from pyspectral import rayleigh
 from pyspectral.rayleigh import BandFrequencyOutOfRange
 from pyspectral.tests.data import (
@@ -36,7 +36,6 @@ from pyspectral.tests.data import (
     TEST_RAYLEIGH_WVL_COORD)
 from pyspectral.utils import RSR_DATA_VERSION
 
-import unittest
 from unittest.mock import patch
 
 TEST_RAYLEIGH_RESULT1 = np.array([10.40727436,   8.69775471], dtype='float32')
@@ -47,10 +46,6 @@ TEST_RAYLEIGH_RESULT_R1 = np.array([16.66666667, 20.83333333, 25.], dtype='float
 TEST_RAYLEIGH_RESULT_R2 = np.array([0., 6.25, 12.5], dtype='float32')
 
 TEST_ZENITH_ANGLES_RESULTS = np.array([68.67631374, 68.67631374, 32., 0.])
-
-# Mock some modules, so we don't need them for tests.
-
-# sys.modules['pyresample'] = MagicMock()
 
 
 class RelativeSpectralResponseTestData(object):
@@ -87,10 +82,10 @@ class RelativeSpectralResponseTestData(object):
         self.rsr[chname]['det-1']['response'] = ch3_resp
 
 
-class TestRayleighDask(unittest.TestCase):
+class TestRayleighDask:
     """Class for testing pyspectral.rayleigh - with dask-arrays as input."""
 
-    def setUp(self):
+    def setup_method(self):
         """Set up the test."""
         self.cwvl = 0.4440124
         self.rsr = RelativeSpectralResponseTestData()
@@ -146,7 +141,7 @@ class TestRayleighDask(unittest.TestCase):
         redband_refl = da.array([108., -0.5])
         refl_corr = self.viirs_rayleigh.get_reflectance(sun_zenith, sat_zenith, azidiff, 'M2', redband_refl)
         np.testing.assert_allclose(refl_corr, TEST_RAYLEIGH_RESULT4)
-        self.assertIsInstance(refl_corr, da.Array)
+        assert isinstance(refl_corr, da.Array)
 
     @patch('os.path.exists')
     @patch('pyspectral.utils.download_luts')
@@ -174,7 +169,7 @@ class TestRayleighDask(unittest.TestCase):
         redband_refl = da.array([14., 5.])
         refl_corr = self.viirs_rayleigh.get_reflectance(sun_zenith, sat_zenith, azidiff, 'M2', redband_refl)
         np.testing.assert_allclose(refl_corr, TEST_RAYLEIGH_RESULT1)
-        self.assertIsInstance(refl_corr, da.Array)
+        assert isinstance(refl_corr, da.Array)
 
         sun_zenith = da.array([60., 20.])
         sat_zenith = da.array([49., 26.])
@@ -182,7 +177,7 @@ class TestRayleighDask(unittest.TestCase):
         redband_refl = da.array([12., 8.])
         refl_corr = self.viirs_rayleigh.get_reflectance(sun_zenith, sat_zenith, azidiff, 'M2', redband_refl)
         np.testing.assert_allclose(refl_corr, TEST_RAYLEIGH_RESULT2)
-        self.assertIsInstance(refl_corr, da.Array)
+        assert isinstance(refl_corr, da.Array)
 
     @patch('os.path.exists')
     @patch('pyspectral.utils.download_luts')
@@ -210,7 +205,7 @@ class TestRayleighDask(unittest.TestCase):
         redband_refl = np.array([14., 5.])
         refl_corr = self.viirs_rayleigh.get_reflectance(sun_zenith, sat_zenith, azidiff, 'M2', redband_refl)
         np.testing.assert_allclose(refl_corr, TEST_RAYLEIGH_RESULT1)
-        self.assertIsInstance(refl_corr, np.ndarray)
+        assert isinstance(refl_corr, np.ndarray)
 
         sun_zenith = np.array([60., 20.])
         sat_zenith = np.array([49., 26.])
@@ -218,13 +213,13 @@ class TestRayleighDask(unittest.TestCase):
         redband_refl = np.array([12., 8.])
         refl_corr = self.viirs_rayleigh.get_reflectance(sun_zenith, sat_zenith, azidiff, 'M2', redband_refl)
         np.testing.assert_allclose(refl_corr, TEST_RAYLEIGH_RESULT2)
-        self.assertIsInstance(refl_corr, np.ndarray)
+        assert isinstance(refl_corr, np.ndarray)
 
 
-class TestRayleigh(unittest.TestCase):
+class TestRayleigh:
     """Class for testing pyspectral.rayleigh."""
 
-    def setUp(self):
+    def setup_method(self):
         """Set up the test."""
         self.cwvl = 0.4440124
         self.rsr = RelativeSpectralResponseTestData()
@@ -255,12 +250,12 @@ class TestRayleigh(unittest.TestCase):
             instance.rsr = RelativeSpectralResponseTestData().rsr
 
             this = rayleigh.Rayleigh('Himawari-8', 'ahi')
-            with self.assertRaises(BandFrequencyOutOfRange):
+            with pytest.raises(BandFrequencyOutOfRange):
                 this.get_effective_wavelength(0.9)
 
             # Only ch3 (~0.63) testdata implemented yet...
             ewl = this.get_effective_wavelength(0.65)
-            self.assertAlmostEqual(ewl, 0.6356167)
+            np.testing.assert_allclose(ewl, 0.6356167)
 
         # mymock:
         with patch('pyspectral.rayleigh.RelativeSpectralResponse') as mymock:
@@ -269,11 +264,11 @@ class TestRayleigh(unittest.TestCase):
 
             this = rayleigh.Rayleigh('Himawari-8', 'ahi')
             ewl = this.get_effective_wavelength(0.7)
-            self.assertEqual(ewl, 0.7)
+            assert ewl == 0.7
             ewl = this.get_effective_wavelength(0.9)
-            self.assertEqual(ewl, 0.9)
+            assert ewl == 0.9
             ewl = this.get_effective_wavelength(0.455)
-            self.assertEqual(ewl, 0.455)
+            assert ewl == 0.455
 
     @patch('os.path.exists')
     @patch('pyspectral.utils.download_luts')
@@ -282,23 +277,22 @@ class TestRayleigh(unittest.TestCase):
         download_luts.return_code = None
         exists.return_code = True
 
-        # mymock:
         with patch('pyspectral.rayleigh.RelativeSpectralResponse') as mymock:
             instance = mymock.return_value
             instance.rsr = RelativeSpectralResponseTestData().rsr
 
-            with self.assertRaises(AttributeError):
-                this = rayleigh.Rayleigh('Himawari-8', 'ahi', atmosphere='unknown')
+            with pytest.raises(AttributeError):
+                rayleigh.Rayleigh('Himawari-8', 'ahi', atmosphere='unknown')
 
-            with self.assertRaises(AttributeError):
-                this = rayleigh.Rayleigh('Himawari-8', 'ahi', aerosol_type='unknown')
+            with pytest.raises(AttributeError):
+                rayleigh.Rayleigh('Himawari-8', 'ahi', aerosol_type='unknown')
 
             this = rayleigh.Rayleigh('Himawari-8', 'ahi', atmosphere='subarctic winter')
-            self.assertTrue(os.path.basename(this.reflectance_lut_filename).endswith('subarctic_winter.h5'))
-            self.assertTrue(this.sensor == 'ahi')
+            assert os.path.basename(this.reflectance_lut_filename).endswith('subarctic_winter.h5')
+            assert this.sensor == 'ahi'
 
             this = rayleigh.Rayleigh('NOAA-19', 'avhrr/3', atmosphere='tropical')
-            self.assertTrue(this.sensor == 'avhrr3')
+            assert this.sensor == 'avhrr3'
 
     def test_cliping_angles_with_nans(self):
         """Test the cliping of angles outside coordinate range - with nan's in input."""
@@ -314,13 +308,13 @@ class TestRayleigh(unittest.TestCase):
         in_rayleigh = [50, 50, 50]
         # Test case where no reduction is done.
         retv = self.viirs_rayleigh.reduce_rayleigh_highzenith(sun_zenith, in_rayleigh, 70., 90., 1)
-        self.assertTrue(np.allclose(retv, in_rayleigh))
+        np.testing.assert_allclose(retv, in_rayleigh)
         # Test case where moderate reduction is performed.
         retv = self.viirs_rayleigh.reduce_rayleigh_highzenith(sun_zenith, in_rayleigh, 30., 90., 1)
-        self.assertTrue(np.allclose(retv, TEST_RAYLEIGH_RESULT_R1))
+        np.testing.assert_allclose(retv, TEST_RAYLEIGH_RESULT_R1)
         # Test case where extreme reduction is performed.
         retv = self.viirs_rayleigh.reduce_rayleigh_highzenith(sun_zenith, in_rayleigh, 30., 90., 1.5)
-        self.assertTrue(np.allclose(retv, TEST_RAYLEIGH_RESULT_R2))
+        np.testing.assert_allclose(retv, TEST_RAYLEIGH_RESULT_R2)
 
     @patch('pyspectral.rayleigh.HAVE_DASK', False)
     @patch('os.path.exists')

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -25,7 +25,6 @@
 
 import os
 import logging
-import tempfile
 import numpy as np
 from pyspectral.config import get_config
 from pyspectral.bandnames import BANDNAMES
@@ -117,19 +116,11 @@ for atype in AEROSOL_TYPES:
     HTTPS_RAYLEIGH_LUTS[atype] = url
 
 
-def _get_rayleigh_lut_dir(aerosol_type):
+def get_rayleigh_lut_dir(aerosol_type):
+    """Get the rayleight LUT directory for the specified aerosol type."""
     conf = get_config()
     local_rayleigh_dir = conf.get('rayleigh_dir')
     return os.path.join(local_rayleigh_dir, aerosol_type)
-
-
-# only create one temporary directory once
-DEFAULT_TB2RAD_DIR = tempfile.gettempdir()
-
-
-def _get_tb2rad_dir():
-    conf = get_config()
-    return conf.get('tb2rad_dir', DEFAULT_TB2RAD_DIR)
 
 
 def convert2wavenumber(rsr):
@@ -350,7 +341,7 @@ def download_luts(**kwargs):
         http = HTTPS_RAYLEIGH_LUTS[subname]
         LOG.debug('URL = %s', http)
 
-        subdir_path = _get_rayleigh_lut_dir(subname)
+        subdir_path = get_rayleigh_lut_dir(subname)
         try:
             LOG.debug('Create directory: %s', subdir_path)
             if not dry_run:

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -117,7 +117,7 @@ for atype in AEROSOL_TYPES:
     HTTPS_RAYLEIGH_LUTS[atype] = url
 
 
-def get_rayleigh_lut_dir(aerosol_type):
+def _get_rayleigh_lut_dir(aerosol_type):
     conf = get_config()
     local_rayleigh_dir = conf.get('rayleigh_dir')
     return os.path.join(local_rayleigh_dir, aerosol_type)
@@ -127,7 +127,7 @@ def get_rayleigh_lut_dir(aerosol_type):
 DEFAULT_TB2RAD_DIR = tempfile.gettempdir()
 
 
-def get_tb2rad_dir():
+def _get_tb2rad_dir():
     conf = get_config()
     return conf.get('tb2rad_dir', DEFAULT_TB2RAD_DIR)
 
@@ -350,7 +350,7 @@ def download_luts(**kwargs):
         http = HTTPS_RAYLEIGH_LUTS[subname]
         LOG.debug('URL = %s', http)
 
-        subdir_path = get_rayleigh_lut_dir(subname)
+        subdir_path = _get_rayleigh_lut_dir(subname)
         try:
             LOG.debug('Create directory: %s', subdir_path)
             if not dry_run:


### PR DESCRIPTION
### Update Description

After letting this PR sit for a while I had some other ideas and also started playing around with generating satpy products using a dask distributed scheduler (LocalCluster). I found out that the rayleigh correction can't be used on a distributed dask scheduler as it opens HDF5 files with h5py and these objects can't be serialized. The solution is to either load the numpy arrays into memory and pass them to dask or to open the files inside a `map_blocks` call so the file is only open on the workers and then closed.

This PR uses both. It loads the LUT file initially and gets the rayleigh reflectance and wavelength data. Using this it filters out the specific section of the rayleigh LUT and passes that to a `map_blocks` call. Inside that map blocks function the LUT is loaded again and gets the 3 angle LUT variables which are used for interpolation. There may be some other optimizations that could be made, but this works pretty well so far to make the rayleigh correction dask distributed friendly and saves multiple GBs of memory. See the latest comments below for more information.

### Original Description

I just wanted to see what would happen if I rearranged how the rayleigh code did stuff and if it improved performance. I would consider this negligible, but didn't want to lose the work so here it is. The main difference here is that the LUT file for rayleigh correction (the HDF5 file) is loaded repeatedly for each chunk. This means that dask doesn't have to cache or hold onto the LUT information, but it also means that the workers have to have access to the LUT files. This may not be true in a distributed dask setting.

Original:

![image](https://user-images.githubusercontent.com/1828519/144876814-0752d29d-9e43-4323-bf13-04e8b91d8589.png)

New:

![image](https://user-images.githubusercontent.com/1828519/144876850-e765b067-091b-4648-b918-cf993fa41fde.png)

CC @simonrp84 who was interested in this work.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
