### PR TITLE
Add technique to reduce Rayleigh contribution at high zenith angles

### DIFF
--- a/doc/rayleigh_correction.rst
+++ b/doc/rayleigh_correction.rst
@@ -110,6 +110,31 @@ if you want another setup, e.g.:
   [[ 10.01281363   9.65488615]
    [  9.78070046   9.70335278]]
 
+At high solar zenith angles the assumptions used in the simulations begin to break
+down, which can lead to unrealistic correction values. In particular, for true color
+imagery this often results in the red channel being too bright compared to the
+green and / or blue channels.
+We have implemented an optional scaling method to minimise this overcorrection at
+high solar zeniths, `reduce_rayleigh`:
+
+  >>> from pyspectral.rayleigh import Rayleigh
+  >>> import numpy as np
+  >>> viirs = Rayleigh('Suomi-NPP', 'viirs', atmosphere='midlatitude summer', rural_aerosol=True)
+  >>> sunz = np.array([[32., 40.], [80., 88.]])
+  >>> satz = np.array([[45., 20.], [46., 21.]])
+  >>> ssadiff = np.array([[110, 170], [120, 180]])
+  >>> refl_cor_m2 = viirs.get_reflectance(sunz, satz, ssadiff, 0.45, redband)
+  [[ 10.40291763 9.654881]
+   [ 30.9275331  39.41288558]]
+  >>> reduced_refl_cor_m2 = viirs.reduce_rayleigh_highzenith(sunz, refl_cor_m2, 70., 90., 1.)
+  [[ 10.40291763 9.654881],
+   [ 15.46376655 3.94128856]]
+
+These reduced atmospheric correction (primarily due to increased Rayleigh
+scattering in the clear atmosphere) values can then be used to correct the
+original satellite reflectance data to produce more visually pleasing imagery,
+also at low sun elevations. Due to the nature of this reduction method they
+should not be used for any scientific analysis.
 
 .. _Satpy: http://www.github.com/pytroll/satpy
 .. _zenodo: https://doi.org/10.5281/zenodo.1288441

--- a/pyspectral/rayleigh.py
+++ b/pyspectral/rayleigh.py
@@ -336,6 +336,19 @@ class Rayleigh(RayleighConfigBaseClass):
 
         return res
 
+    @staticmethod
+    def reduce_rayleigh_highzenith(zenith, rayref, thresh_zen, maxzen, strength):
+        """Reduce the Rayleigh correction amount at high zenith angles.
+        This linearly scales the Rayleigh reflectance, `rayref`, for solar or satellite zenith angles, `zenith`,
+        above a threshold angle, `thresh_zen`. Between `thresh_zen` and `maxzen` the Rayleigh reflectance will
+        be linearly scaled, from one at `thresh_zen` to zero at `maxzen`.
+        """
+        LOG.info("Reducing Rayleigh effect at high zenith angles.")
+        factor = 1. - strength * where(zenith < thresh_zen, 0, (zenith - thresh_zen) / (maxzen - thresh_zen))
+        # For low zenith factor can be greater than one, so we need to clip it into a sensible range.
+        factor = clip(factor, 0, 1)
+        return rayref * factor
+
 
 def get_reflectance_lut_from_file(filename):
     """Get reflectance LUT.

--- a/pyspectral/rayleigh.py
+++ b/pyspectral/rayleigh.py
@@ -204,8 +204,8 @@ class Rayleigh(RayleighConfigBaseClass):
                     'Requested band frequency should be between 0.4 and 0.8 microns!')
             bandname = get_bandname_from_wavelength(self.sensor, bandname, rsr.rsr)
 
-        wvl, resp = rsr.rsr[bandname][
-            'det-1']['wavelength'], rsr.rsr[bandname]['det-1']['response']
+        wvl, resp = (rsr.rsr[bandname]['det-1']['wavelength'],
+                     rsr.rsr[bandname]['det-1']['response'])
 
         cwvl = get_central_wave(wvl, resp, weight=1. / wvl**4)
         LOG.debug("Band name: %s  Effective wavelength: %f", bandname, cwvl)

--- a/pyspectral/tests/test_rayleigh.py
+++ b/pyspectral/tests/test_rayleigh.py
@@ -50,6 +50,8 @@ TEST_RAYLEIGH_RESULT1 = np.array([10.40727436,   8.69775471], dtype='float32')
 TEST_RAYLEIGH_RESULT2 = np.array([9.71696059, 8.51415689], dtype='float32')
 TEST_RAYLEIGH_RESULT3 = np.array([5.61532271,  8.69267476], dtype='float32')
 TEST_RAYLEIGH_RESULT4 = np.array([0.0,   8.69775471], dtype='float32')
+TEST_RAYLEIGH_RESULT_R1 = np.array([16.66666667, 20.83333333, 25.], dtype='float32')
+TEST_RAYLEIGH_RESULT_R2 = np.array([0., 6.25, 12.5], dtype='float32')
 
 TEST_ZENITH_ANGLES_RESULTS = np.array([68.67631374, 68.67631374, 32., 0.])
 
@@ -334,6 +336,23 @@ class TestRayleigh(unittest.TestCase):
         result = self.viirs_rayleigh._clip_angles_inside_coordinate_range(zenith_angle, 2.75)
 
         np.testing.assert_allclose(result, TEST_ZENITH_ANGLES_RESULTS)
+
+    def test_rayleigh_reduction(self):
+        """Test the code that reduces Rayleigh correction for high zenith angles."""
+
+        # Test the Rayleigh reduction code
+        sun_zenith = np.array([70., 65., 60.])
+        in_rayleigh = [50, 50, 50]
+        # Test case where no reduction is done.
+        retv = self.viirs_rayleigh.reduce_rayleigh_highzenith(sun_zenith, in_rayleigh, 70., 90., 1)
+        self.assertTrue(np.allclose(retv, in_rayleigh))
+        # Test case where moderate reduction is performed.
+        retv = self.viirs_rayleigh.reduce_rayleigh_highzenith(sun_zenith, in_rayleigh, 30., 90., 1)
+        self.assertTrue(np.allclose(retv, TEST_RAYLEIGH_RESULT_R1))
+        # Test case where extreme reduction is performed.
+        retv = self.viirs_rayleigh.reduce_rayleigh_highzenith(sun_zenith, in_rayleigh, 30., 90., 1.5)
+        self.assertTrue(np.allclose(retv, TEST_RAYLEIGH_RESULT_R2))
+
 
     @patch('pyspectral.rayleigh.HAVE_DASK', False)
     @patch('os.path.exists')

--- a/pyspectral/tests/test_rayleigh.py
+++ b/pyspectral/tests/test_rayleigh.py
@@ -36,15 +36,8 @@ from pyspectral.tests.data import (
     TEST_RAYLEIGH_WVL_COORD)
 from pyspectral.utils import RSR_DATA_VERSION
 
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
-
-if sys.version_info < (3,):
-    from mock import patch
-else:
-    from unittest.mock import patch
+import unittest
+from unittest.mock import patch
 
 TEST_RAYLEIGH_RESULT1 = np.array([10.40727436,   8.69775471], dtype='float32')
 TEST_RAYLEIGH_RESULT2 = np.array([9.71696059, 8.51415689], dtype='float32')
@@ -352,7 +345,6 @@ class TestRayleigh(unittest.TestCase):
         # Test case where extreme reduction is performed.
         retv = self.viirs_rayleigh.reduce_rayleigh_highzenith(sun_zenith, in_rayleigh, 30., 90., 1.5)
         self.assertTrue(np.allclose(retv, TEST_RAYLEIGH_RESULT_R2))
-
 
     @patch('pyspectral.rayleigh.HAVE_DASK', False)
     @patch('os.path.exists')


### PR DESCRIPTION
At present, the Rayleigh correction code calculates the Rayleigh reflectance as a function of zenith and azimuth angles. This works well and is accurate in many cases, but at high zenith the assumptions used in the Look-Up Tables behind the calculation break down and can produce unphsyically high Rayleigh contributions.

In this PR, I add a simple (non-radiative transfer) method for reducing this effect, which results in more visually pleasing images at high zenith angles. The method linearly reduces the Rayleigh contribution between a threshold angle and whatever the maximum zenith angle for the LUTs is: `new_rayleigh = old_rayleigh * factor(zenith, thresh_zen, maxzen)`. The relative strength of this effect can be altered via a new variable in the `get_reflectance` function call, `reduce_strength`. This correction is only applied to the solar zenith angle, not to high satellite zeniths.

By default, this new technique is *disabled*, and is only enabled if the user passes `reduce_hizen=some_float` to the Rayleigh code's `get_reflectance` function.
Attached is an example of these updates applied to Him-8/AHI data.

The original `true_color_reproduction` composite produced using `main` branches of satpy and pyspectral:
![orig_rez](https://user-images.githubusercontent.com/13449576/146533251-a31caa5c-ca75-4fc4-b7eb-980086141e9b.jpg)
The same composite with this PR enabled, `thresh_zen` is set to 75 degrees and `reduce_strength` is 0.75.
![enabled_75deg_0 7str_rez](https://user-images.githubusercontent.com/13449576/146533253-c550298c-5d05-4356-8453-3955352df1ef.jpg)

Note: As part of this PR I have also removed a bunch of imports from the tests that were only suitable for python 2.x, and were thus unused.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
