### PR TITLE
Creating ABI RSR files for GOES 18 & 19 (FM3 & 4)

### DIFF
--- a/doc/platforms_supported.rst
+++ b/doc/platforms_supported.rst
@@ -2,7 +2,7 @@ Satellite sensors supported
 ===========================
 
 Below we list the satellite sensors for which the relative spectral responses
-have been included in PySpectral. 
+have been included in Pyspectral.
 
 .. list-table:: Satellite sensors supported
     :header-rows: 1
@@ -28,6 +28,12 @@ have been included in PySpectral.
     * - GOES-17 abi
       - `rsr_abi_GOES-17.h5`
       - GOES-S_
+    * - GOES-18 abi
+      - `rsr_abi_GOES-18.h5`
+      - GOES-T_
+    * - GOES-19 abi
+      - `rsr_abi_GOES-19.h5`
+      - GOES-U_
     * - Himawari-8 ahi
       - `rsr_ahi_Himawari-8.h5`
       - JMA_
@@ -70,6 +76,9 @@ have been included in PySpectral.
     * - Sentinel-3A olci
       - `rsr_olci_Sentinel-3A.h5`
       - ESA-Sentinel-OLCI_
+    * - Sentinel-3B olci
+      - `rsr_olci_Sentinel-3B.h5`
+      - ESA-Sentinel-OLCI_
     * - Sentinel-2A msi
       - `rsr_msi_Sentinel-2A.h5`
       - ESA-Sentinel-MSI_
@@ -104,8 +113,10 @@ have been included in PySpectral.
 
 .. _Eumetsat: https://www.eumetsat.int/website/home/Data/Products/Calibration/MSGCalibration/index.html
 .. _GSICS: https://www.star.nesdis.noaa.gov/smcd/GCC/instrInfo-srf.php
-.. _GOES-R: http://ncc.nesdis.noaa.gov/GOESR/docs/GOES-R_ABI_PFM_SRF_CWG_v3.zip
-.. _GOES-S:  http://ncc.nesdis.noaa.gov/GOESR/docs/GOES-R_ABI_FM2_SRF_CWG.zip
+.. _GOES-R: https://ncc.nesdis.noaa.gov/GOESR/docs/GOES-R_ABI_PFM_SRF_CWG_v3.zip
+.. _GOES-S:  https://ncc.nesdis.noaa.gov/GOESR/docs/GOES-R_ABI_FM2_SRF_CWG.zip
+.. _GOES-T:  https://ncc.nesdis.noaa.gov/GOESR/docs/GOES-R_ABI_FM3_SRF_CWG.zip
+.. _GOES-U:  https://ncc.nesdis.noaa.gov/GOESR/docs/GOES-R_ABI_FM4_SRF_CWG.zip
 .. _JMA: http://www.data.jma.go.jp/mscweb/en/himawari89/space_segment/spsg_ahi.html#srf
 .. _ESA-Envisat: http://envisat.esa.int/handbooks/aatsr/aux-files/consolidatedsrfs.xls
 .. _ESA-Sentinel-OLCI: https://sentinel.esa.int/documents/247904/322304/OLCI+SRF+%28NetCDF%29/15cfd7a6-b7bc-4051-87f8-c35d765ae43a

--- a/pyspectral/bandnames.py
+++ b/pyspectral/bandnames.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2021 Adam.Dybbroe
+
+# Author(s):
+
+#   Adam Dybbroe <Firstname.Lastname@smhi.se>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Band name translations."""
+
+BANDNAMES = {}
+BANDNAMES['generic'] = {'VIS006': 'VIS0.6',
+                        'VIS008': 'VIS0.8',
+                        'IR_016': 'NIR1.6',
+                        'IR_039': 'IR3.9',
+                        'WV_062': 'IR6.2',
+                        'WV_073': 'IR7.3',
+                        'IR_087': 'IR8.7',
+                        'IR_097': 'IR9.7',
+                        'IR_108': 'IR10.8',
+                        'IR_120': 'IR12.0',
+                        'IR_134': 'IR13.4',
+                        'HRV': 'HRV',
+                        'I01': 'I1',
+                        'I02': 'I2',
+                        'I03': 'I3',
+                        'I04': 'I4',
+                        'I05': 'I5',
+                        'M01': 'M1',
+                        'M02': 'M2',
+                        'M03': 'M3',
+                        'M04': 'M4',
+                        'M05': 'M5',
+                        'M06': 'M6',
+                        'M07': 'M7',
+                        'M08': 'M8',
+                        'M09': 'M9',
+                        'C01': 'ch1',
+                        'C02': 'ch2',
+                        'C03': 'ch3',
+                        'C04': 'ch4',
+                        'C05': 'ch5',
+                        'C06': 'ch6',
+                        'C07': 'ch7',
+                        'C08': 'ch8',
+                        'C09': 'ch9',
+                        'C10': 'ch10',
+                        'C11': 'ch11',
+                        'C12': 'ch12',
+                        'C13': 'ch13',
+                        'C14': 'ch14',
+                        'C15': 'ch15',
+                        'C16': 'ch16',
+                        }
+# handle arbitrary channel numbers
+for chan_num in range(1, 37):
+    BANDNAMES['generic'][str(chan_num)] = 'ch{:d}'.format(chan_num)
+
+# MODIS RSR files were made before 'chX' became standard in pyspectral
+BANDNAMES['modis'] = {str(chan_num): str(chan_num) for chan_num in range(1, 37)}
+
+BANDNAMES['seviri'] = {'VIS006': 'VIS0.6',
+                       'VIS008': 'VIS0.8',
+                       'IR_016': 'NIR1.6',
+                       'IR_039': 'IR3.9',
+                       'WV_062': 'IR6.2',
+                       'WV_073': 'IR7.3',
+                       'IR_087': 'IR8.7',
+                       'IR_097': 'IR9.7',
+                       'IR_108': 'IR10.8',
+                       'IR_120': 'IR12.0',
+                       'IR_134': 'IR13.4',
+                       'HRV': 'HRV'}
+
+BANDNAMES['viirs'] = {'I01': 'I1',
+                      'I02': 'I2',
+                      'I03': 'I3',
+                      'I04': 'I4',
+                      'I05': 'I5',
+                      'M01': 'M1',
+                      'M02': 'M2',
+                      'M03': 'M3',
+                      'M04': 'M4',
+                      'M05': 'M5',
+                      'M06': 'M6',
+                      'M07': 'M7',
+                      'M08': 'M8',
+                      'M09': 'M9',
+                      }
+
+BANDNAMES['avhrr-3'] = {'1': 'ch1',
+                        '2': 'ch2',
+                        '3b': 'ch3b',
+                        '3a': 'ch3a',
+                        '4': 'ch4',
+                        '5': 'ch5'}
+
+BANDNAMES['abi'] = {'C01': 'ch1',
+                    'C02': 'ch2',
+                    'C03': 'ch3',
+                    'C04': 'ch4',
+                    'C05': 'ch5',
+                    'C06': 'ch6',
+                    'C07': 'ch7',
+                    'C08': 'ch8',
+                    'C09': 'ch9',
+                    'C10': 'ch10',
+                    'C11': 'ch11',
+                    'C12': 'ch12',
+                    'C13': 'ch13',
+                    'C14': 'ch14',
+                    'C15': 'ch15',
+                    'C16': 'ch16'
+                    }
+
+BANDNAMES['ahi'] = {'B01': 'ch1',
+                    'B02': 'ch2',
+                    'B03': 'ch3',
+                    'B04': 'ch4',
+                    'B05': 'ch5',
+                    'B06': 'ch6',
+                    'B07': 'ch7',
+                    'B08': 'ch8',
+                    'B09': 'ch9',
+                    'B10': 'ch10',
+                    'B11': 'ch11',
+                    'B12': 'ch12',
+                    'B13': 'ch13',
+                    'B14': 'ch14',
+                    'B15': 'ch15',
+                    'B16': 'ch16'
+                    }
+
+BANDNAMES['ami'] = {'VI004': 'ch1',
+                    'VI005': 'ch2',
+                    'VI006': 'ch3',
+                    'VI008': 'ch4',
+                    'NR013': 'ch5',
+                    'NR016': 'ch6',
+                    'SW038': 'ch7',
+                    'WV063': 'ch8',
+                    'WV069': 'ch9',
+                    'WV073': 'ch10',
+                    'IR087': 'ch11',
+                    'IR096': 'ch12',
+                    'IR105': 'ch13',
+                    'IR112': 'ch14',
+                    'IR123': 'ch15',
+                    'IR133': 'ch16'
+                    }
+
+BANDNAMES['fci'] = {'vis_04': 'ch1',
+                    'vis_05': 'ch2',
+                    'vis_06': 'ch3',
+                    'vis_08': 'ch4',
+                    'vis_09': 'ch5',
+                    'nir_13': 'ch6',
+                    'nir_16': 'ch7',
+                    'nir_22': 'ch8',
+                    'ir_38': 'ch9',
+                    'wv_63': 'ch10',
+                    'wv_73': 'ch11',
+                    'ir_87': 'ch12',
+                    'ir_97': 'ch13',
+                    'ir_105': 'ch14',
+                    'ir_123': 'ch15',
+                    'ir_133': 'ch16'
+                    }
+
+BANDNAMES['slstr'] = {'S1': 'ch1',
+                      'S2': 'ch2',
+                      'S3': 'ch3',
+                      'S4': 'ch4',
+                      'S5': 'ch5',
+                      'S6': 'ch6',
+                      'S7': 'ch7',
+                      'S8': 'ch8',
+                      'S9': 'ch9',
+                      'F1': 'ch7',
+                      'F2': 'ch8',
+                      }

--- a/pyspectral/tests/test_utils.py
+++ b/pyspectral/tests/test_utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2014-2020 Pytroll developers
+# Copyright (c) 2014-2021 Pytroll developers
 #
 # Author(s):
 #
@@ -150,10 +150,10 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(bname, ['ch13', 'ch14'])
 
         # uses generic channel mapping where '20' -> 'ch20'
-        bandname = utils.get_bandname_from_wavelength('abi', 3.7, TEST_RSR)
+        bandname = utils.get_bandname_from_wavelength('ufo', 3.7, TEST_RSR)
         self.assertEqual(bandname, 'ch20')
 
-        bandname = utils.get_bandname_from_wavelength('abi', 3.0, TEST_RSR)
+        bandname = utils.get_bandname_from_wavelength('ufo', 3.0, TEST_RSR)
         self.assertIsNone(bandname)
 
     @staticmethod

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -28,165 +28,13 @@ import logging
 import tempfile
 import numpy as np
 from pyspectral.config import get_config
+from pyspectral.bandnames import BANDNAMES
 
 LOG = logging.getLogger(__name__)
 
 WAVE_LENGTH = 'wavelength'
 WAVE_NUMBER = 'wavenumber'
 
-BANDNAMES = {}
-BANDNAMES['generic'] = {'VIS006': 'VIS0.6',
-                        'VIS008': 'VIS0.8',
-                        'IR_016': 'NIR1.6',
-                        'IR_039': 'IR3.9',
-                        'WV_062': 'IR6.2',
-                        'WV_073': 'IR7.3',
-                        'IR_087': 'IR8.7',
-                        'IR_097': 'IR9.7',
-                        'IR_108': 'IR10.8',
-                        'IR_120': 'IR12.0',
-                        'IR_134': 'IR13.4',
-                        'HRV': 'HRV',
-                        'I01': 'I1',
-                        'I02': 'I2',
-                        'I03': 'I3',
-                        'I04': 'I4',
-                        'I05': 'I5',
-                        'M01': 'M1',
-                        'M02': 'M2',
-                        'M03': 'M3',
-                        'M04': 'M4',
-                        'M05': 'M5',
-                        'M06': 'M6',
-                        'M07': 'M7',
-                        'M08': 'M8',
-                        'M09': 'M9',
-                        'C01': 'ch1',
-                        'C02': 'ch2',
-                        'C03': 'ch3',
-                        'C04': 'ch4',
-                        'C05': 'ch5',
-                        'C06': 'ch6',
-                        'C07': 'ch7',
-                        'C08': 'ch8',
-                        'C09': 'ch9',
-                        'C10': 'ch10',
-                        'C11': 'ch11',
-                        'C12': 'ch12',
-                        'C13': 'ch13',
-                        'C14': 'ch14',
-                        'C15': 'ch15',
-                        'C16': 'ch16',
-                        }
-# handle arbitrary channel numbers
-for chan_num in range(1, 37):
-    BANDNAMES['generic'][str(chan_num)] = 'ch{:d}'.format(chan_num)
-
-# MODIS RSR files were made before 'chX' became standard in pyspectral
-BANDNAMES['modis'] = {str(chan_num): str(chan_num) for chan_num in range(1, 37)}
-
-BANDNAMES['seviri'] = {'VIS006': 'VIS0.6',
-                       'VIS008': 'VIS0.8',
-                       'IR_016': 'NIR1.6',
-                       'IR_039': 'IR3.9',
-                       'WV_062': 'IR6.2',
-                       'WV_073': 'IR7.3',
-                       'IR_087': 'IR8.7',
-                       'IR_097': 'IR9.7',
-                       'IR_108': 'IR10.8',
-                       'IR_120': 'IR12.0',
-                       'IR_134': 'IR13.4',
-                       'HRV': 'HRV'}
-
-BANDNAMES['viirs'] = {'I01': 'I1',
-                      'I02': 'I2',
-                      'I03': 'I3',
-                      'I04': 'I4',
-                      'I05': 'I5',
-                      'M01': 'M1',
-                      'M02': 'M2',
-                      'M03': 'M3',
-                      'M04': 'M4',
-                      'M05': 'M5',
-                      'M06': 'M6',
-                      'M07': 'M7',
-                      'M08': 'M8',
-                      'M09': 'M9',
-                      }
-
-BANDNAMES['avhrr-3'] = {'1': 'ch1',
-                        '2': 'ch2',
-                        '3b': 'ch3b',
-                        '3a': 'ch3a',
-                        '4': 'ch4',
-                        '5': 'ch5'}
-
-BANDNAMES['ahi'] = {'B01': 'ch1',
-                    'B02': 'ch2',
-                    'B03': 'ch3',
-                    'B04': 'ch4',
-                    'B05': 'ch5',
-                    'B06': 'ch6',
-                    'B07': 'ch7',
-                    'B08': 'ch8',
-                    'B09': 'ch9',
-                    'B10': 'ch10',
-                    'B11': 'ch11',
-                    'B12': 'ch12',
-                    'B13': 'ch13',
-                    'B14': 'ch14',
-                    'B15': 'ch15',
-                    'B16': 'ch16'
-                    }
-
-BANDNAMES['ami'] = {'VI004': 'ch1',
-                    'VI005': 'ch2',
-                    'VI006': 'ch3',
-                    'VI008': 'ch4',
-                    'NR013': 'ch5',
-                    'NR016': 'ch6',
-                    'SW038': 'ch7',
-                    'WV063': 'ch8',
-                    'WV069': 'ch9',
-                    'WV073': 'ch10',
-                    'IR087': 'ch11',
-                    'IR096': 'ch12',
-                    'IR105': 'ch13',
-                    'IR112': 'ch14',
-                    'IR123': 'ch15',
-                    'IR133': 'ch16'
-                    }
-
-BANDNAMES['fci'] = {'vis_04': 'ch1',
-                    'vis_05': 'ch2',
-                    'vis_06': 'ch3',
-                    'vis_08': 'ch4',
-                    'vis_09': 'ch5',
-                    'nir_13': 'ch6',
-                    'nir_16': 'ch7',
-                    'nir_22': 'ch8',
-                    'ir_38': 'ch9',
-                    'wv_63': 'ch10',
-                    'wv_73': 'ch11',
-                    'ir_87': 'ch12',
-                    'ir_97': 'ch13',
-                    'ir_105': 'ch14',
-                    'ir_123': 'ch15',
-                    'ir_133': 'ch16'
-                    }
-
-BANDNAMES['slstr'] = {'S1': 'ch1',
-                      'S2': 'ch2',
-                      'S3': 'ch3',
-                      'S4': 'ch4',
-                      'S5': 'ch5',
-                      'S6': 'ch6',
-                      'S7': 'ch7',
-                      'S8': 'ch8',
-                      'S9': 'ch9',
-                      'F1': 'ch7',
-                      'F2': 'ch8',
-                      }
 
 INSTRUMENTS = {'NOAA-19': 'avhrr/3',
                'NOAA-18': 'avhrr/3',
@@ -222,10 +70,10 @@ INSTRUMENTS = {'NOAA-19': 'avhrr/3',
                'MTG-I1': 'fci'
                }
 
-HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/4305549/files/pyspectral_rsr_data.tgz"
+HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/5797957/files/pyspectral_rsr_data.tgz"
 
 RSR_DATA_VERSION_FILENAME = "PYSPECTRAL_RSR_VERSION"
-RSR_DATA_VERSION = "v1.0.16"
+RSR_DATA_VERSION = "v1.0.17"
 
 ATM_CORRECTION_LUT_VERSION = {}
 ATM_CORRECTION_LUT_VERSION['antarctic_aerosol'] = {'version': 'v1.0.1',

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2014-2020 Pytroll developers
+# Copyright (c) 2014-2021 Pytroll developers
 #
 # Author(s):
 #
@@ -607,8 +607,10 @@ def get_wave_range(in_chan, threshold=0.15):
 
 def convert2str(value):
     """Convert a value to string.
+
     Args:
         value: Either a str, bytes or 1-element numpy array
+
     """
     value = bytes2string(value)
     return np2str(value)
@@ -616,11 +618,13 @@ def convert2str(value):
 
 def np2str(value):
     """Convert an `numpy.string_` to str.
+
     Args:
         value (ndarray): scalar or 1-element numpy array to convert
     Raises:
         ValueError: if value is array larger than 1-element or it is not of
                     type `numpy.string_` or it is not a numpy array
+
     """
     if isinstance(value, str):
         return value

--- a/rsr_convert_scripts/abi_rsr.py
+++ b/rsr_convert_scripts/abi_rsr.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2016 - 2018 Pytroll developers
+# Copyright (c) 2016 - 2021 Pytroll developers
 #
 # Author(s):
 #
-#   Adam.Dybbroe <adam.dybbroe@smhi.se>
+#   Adam Dybbroe <Firstname.Lastname@smhi.se>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,7 +20,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Reading the original raw GOES-R ABI spectral responses and generating the
+"""Read raw GOES-R series ABI RSR and generate HDF5 files.
+
+Reading the original raw GOES-R ABI spectral responses and generating the
 internal pyspectral formatet hdf5.
 
 https://ncc.nesdis.noaa.gov/GOESR/ABI.php
@@ -42,14 +44,10 @@ ABI_BAND_NAMES = ['ch1', 'ch2', 'ch3', 'ch4',
 
 
 class AbiRSR(InstrumentRSR):
-
-    """Class for GOES-R ABI RSR"""
+    """Class for GOES-R ABI RSR."""
 
     def __init__(self, bandname, platform_name):
-        """
-        Read the GOES-R ABI relative spectral responses for all channels.
-
-        """
+        """Read the GOES-R ABI relative spectral responses for all channels."""
         super(AbiRSR, self).__init__(bandname, platform_name,
                                      ABI_BAND_NAMES)
 
@@ -69,27 +67,21 @@ class AbiRSR(InstrumentRSR):
         self.filename = self.requested_band_filename
 
     def _load(self, scale=1.0):
-        """Load the ABI relative spectral responses
-        """
-
+        """Load the ABI relative spectral responses."""
         LOG.debug("File: %s", str(self.requested_band_filename))
 
         data = np.genfromtxt(self.requested_band_filename,
                              unpack=True,
-                             names=['wavelength',
-                                    'wavenumber',
-                                    'response'],
                              skip_header=2)
-
-        wvl = data['wavelength'] * scale
-        resp = data['response']
+        wvl = data[0] * scale
+        resp = data[2]
 
         self.rsr = {'wavelength': wvl, 'response': resp}
 
 
 def main():
-    """Main"""
-    for platform_name in ['GOES-16', 'GOES-17', ]:
+    """Create pyspectral hdf5 RSR files for all GOES sats."""
+    for platform_name in ['GOES-18', 'GOES-19', ]:
         tohdf5(AbiRSR, platform_name, ABI_BAND_NAMES)
 
 

--- a/rsr_convert_scripts/abi_rsr.py
+++ b/rsr_convert_scripts/abi_rsr.py
@@ -81,7 +81,7 @@ class AbiRSR(InstrumentRSR):
 
 def main():
     """Create pyspectral hdf5 RSR files for all GOES sats."""
-    for platform_name in ['GOES-18', 'GOES-19', ]:
+    for platform_name in ['GOES-16', 'GOES-17', 'GOES-18', 'GOES-19']:
         tohdf5(AbiRSR, platform_name, ABI_BAND_NAMES)
 
 


### PR DESCRIPTION
Add support for GOES-18 and 19 RSR data.

 - [x] Closes #132 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
