### PR TITLE
Add converter for Electro-L N2 MSU/GS spectral response functions

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,19 @@
+# Project Contributors
+
+The following people have made contributions to this project:
+
+<!--- Use your GitHub account or any other personal reference URL --->
+<!--- If you wish to not use your real name, please use your github username --->
+<!--- The list should be alphabetical by last name if possible, with github usernames at the bottom --->
+<!--- See https://gist.github.com/djhoese/52220272ec73b12eb8f4a29709be110d for auto-generating parts of this list --->
+
+- [K.-Michael Aye](https://github.com/michaelaye)
+- [Adam Dybbroe (adybbroe)](https://github.com/adybbroe)
+- [David Hoese (djhoese)](https://github.com/djhoese)
+- [Christian Kliche](https://github.com/chk)
+- [Panu Lahtinen (pnuu)](https://github.com/pnuu)
+- [Simon R. Proud (simonrp84)](https://github.com/simonrp84)
+- [Martin Raspaud (mraspaud)](https://github.com/mraspaud)
+- [Ronald Scheirer](https://github.com/)
+- [Xin Zhang (zxdawn)](https://github.com/zxdawn)
+- [Rolf Helge ...](https://github.com/HelgeCPH)

--- a/pyspectral/etc/pyspectral.yaml
+++ b/pyspectral/etc/pyspectral.yaml
@@ -226,6 +226,19 @@ download_from_internet: True
 #     ch13: FY4A_AGRI_SRF_CH13.txt
 #     ch14: FY4A_AGRI_SRF_CH14.txt
 
+#Electro-L-N2-msu-gs:
+#     path: /path/to/rsrs/rtcoef_electro-l_2_msugs_srf/
+#     ch1: rtcoef_electro-l_2_msugs_srf_ch01.txt
+#     ch2: rtcoef_electro-l_2_msugs_srf_ch02.txt
+#     ch3: rtcoef_electro-l_2_msugs_srf_ch03.txt
+#     ch4: rtcoef_electro-l_2_msugs_srf_ch04.txt
+#     ch5: rtcoef_electro-l_2_msugs_srf_ch05.txt
+#     ch6: rtcoef_electro-l_2_msugs_srf_ch06.txt
+#     ch7: rtcoef_electro-l_2_msugs_srf_ch07.txt
+#     ch8: rtcoef_electro-l_2_msugs_srf_ch08.txt
+#     ch9: rtcoef_electro-l_2_msugs_srf_ch09.txt
+#     ch10: rtcoef_electro-l_2_msugs_srf_ch10.txt
+
 #FY-3B-virr:
 #  path: /Users/davidh/repos/git/pyspectral/virr_srf/FY3B-VIRR
 #  ch1: ch1.prn

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -1,12 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2014-2021 Pytroll developers
+# Copyright (c) 2014-2022 Pytroll developers
 #
-# Author(s):
-#
-#   Adam.Dybbroe <adam.dybbroe@smhi.se>
-#   Panu Lahtinen <panu.lahtinen@fmi.fi>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -70,10 +66,10 @@ INSTRUMENTS = {'NOAA-19': 'avhrr/3',
                'MTG-I1': 'fci'
                }
 
-HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/5797957/files/pyspectral_rsr_data.tgz"
+HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/6026563/files/pyspectral_rsr_data.tgz"
 
 RSR_DATA_VERSION_FILENAME = "PYSPECTRAL_RSR_VERSION"
-RSR_DATA_VERSION = "v1.0.17"
+RSR_DATA_VERSION = "v1.0.18"
 
 ATM_CORRECTION_LUT_VERSION = {}
 ATM_CORRECTION_LUT_VERSION['antarctic_aerosol'] = {'version': 'v1.0.1',

--- a/rsr_convert_scripts/README.rst
+++ b/rsr_convert_scripts/README.rst
@@ -172,9 +172,13 @@ the pyspectral.yaml file:
      filename: J1_VIIRS_Detector_RSR_V2/J1_VIIRS_RSR_DNBLGS_Detector_Fused_V2S.txt
      bands: [DNB]
 
+.. code::
 
-Adam Dybbroe
-Sat Dec  1 17:39:48 2018
+   %> python msu_gs_reader.py
+
+Converts RSRs for the MSU-GS sensor aboard Electro-L N2. RSRs were retrieved from the NWP-SAF.
+Filenames look like:
+``rtcoef_electro-l_2_msugs_srf_ch01.txt``
 
 .. code::
 
@@ -184,4 +188,7 @@ Converting the FY-3B or FY-3C VIRR spectral responses to HDF5. Original files
 for FY-3B come as ``.prn`` text files for each channel (ex. ``ch1.prn``). For
 FY-3C they come as ``.txt`` text files for channels 1, 2, 6, 7, 8, 9, and 10
 only with names like ``FY3C_VIRR_CH01.txt``.
+
+PyTroll developers
+
 

--- a/rsr_convert_scripts/msu_gs_reader.py
+++ b/rsr_convert_scripts/msu_gs_reader.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2022 Pytroll developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Read the Electro-L N2 MSU-GS spectral response functions. Data from the NWPSAF:
+https://nwp-saf.eumetsat.int/downloads/rtcoef_rttov13/ir_srf/rtcoef_electro-l_2_msugs_srf.html
+
+"""
+
+import os
+import numpy as np
+from pyspectral.utils import convert2hdf5 as tohdf5
+from pyspectral.raw_reader import InstrumentRSR
+import logging
+
+LOG = logging.getLogger(__name__)
+
+MSUGS_BAND_NAMES = ['ch1', 'ch2', 'ch3', 'ch4', 'ch5',
+                    'ch6', 'ch7', 'ch8', 'ch9', 'ch10']
+
+#: Default time format
+_DEFAULT_TIME_FORMAT = '%Y-%m-%d %H:%M:%S'
+
+#: Default log format
+_DEFAULT_LOG_FORMAT = '[%(levelname)s: %(asctime)s : %(name)s] %(message)s'
+
+
+class MsugsRSR(InstrumentRSR):
+    """Container for the Electro-L N2 MSU-GS relative spectral response data"""
+
+    def __init__(self, bandname, platform_name):
+
+        super(MsugsRSR, self).__init__(
+            bandname, platform_name, MSUGS_BAND_NAMES)
+
+        self.instrument = 'msu-gs'
+        self._get_options_from_config()
+        self._get_bandfilenames()
+
+        LOG.debug("Filenames: %s", str(self.filenames))
+        if self.filenames[bandname] and os.path.exists(self.filenames[bandname]):
+            self.requested_band_filename = self.filenames[bandname]
+            self._load()
+
+        else:
+            LOG.warning("Couldn't find an existing file for this band: %s",
+                        str(self.bandname))
+
+        # To be compatible with VIIRS....
+        self.filename = self.requested_band_filename
+
+        self.unit = 'micrometer'
+        self.wavespace = 'wavelength'
+
+    def _load(self, scale=10000.0):
+        """Load the MSU-GS RSR data for the band requested"""
+        data = np.genfromtxt(self.requested_band_filename,
+                             unpack=True,
+                             names=['wavenumber',
+                                    'response'],
+                             skip_header=4)
+
+        # Data are wavenumbers in cm-1:
+        wavelength = 1. / data[0][::-1] * scale
+        response = data[1][::-1]
+
+        # The real AMI has more than one detectors I assume. However, for now
+        # we store the single rsr available in the NWPSAF coefficient files:
+        self.rsr = {'wavelength': wavelength, 'response': response}
+
+
+def main():
+    """Main"""
+    for platform_name in ['Electro-L-N2', ]:
+        tohdf5(MsugsRSR, platform_name, MSUGS_BAND_NAMES)
+
+
+if __name__ == "__main__":
+    import sys
+
+    LOG = logging.getLogger('msu_gs_rsr')
+    handler = logging.StreamHandler(sys.stderr)
+
+    formatter = logging.Formatter(fmt=_DEFAULT_LOG_FORMAT,
+                                  datefmt=_DEFAULT_TIME_FORMAT)
+    handler.setFormatter(formatter)
+    handler.setLevel(logging.DEBUG)
+    LOG.setLevel(logging.DEBUG)
+    LOG.addHandler(handler)
+
+    main()

--- a/rsr_convert_scripts/msu_gs_reader.py
+++ b/rsr_convert_scripts/msu_gs_reader.py
@@ -78,7 +78,7 @@ class MsugsRSR(InstrumentRSR):
         wavelength = 1. / data[0][::-1] * scale
         response = data[1][::-1]
 
-        # The real AMI has more than one detectors I assume. However, for now
+        # The real MSU-GS likely has multiple detectors. However, for now
         # we store the single rsr available in the NWPSAF coefficient files:
         self.rsr = {'wavelength': wavelength, 'response': response}
 


### PR DESCRIPTION
This adds the spectral response functions for the Electro-L N2 satellite's MSU-GS sensor. Unfortunately it's only for the `N2` sat as I can't find RSRs for the `N1` or `N3` sats, but will update the code in future if I can get them.

I also added a section to `pyspectral.yaml` but commented it out and updated the readme. In addition to adding Electro-L to the readme I also took the liberty of changing @adybbroe as author to "Pytroll developers" as I think quite a few people have worked on this. Hope that's OK!

 - [x] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
