### PR TITLE
Cleanup RSR and LUT download functions for clearer usage

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -22,6 +22,7 @@ dependencies:
   - mock
   - pytest
   - pytest-cov
+  - responses
   - appdirs
   - python-geotiepoints
   - pip

--- a/pyspectral/rayleigh.py
+++ b/pyspectral/rayleigh.py
@@ -367,4 +367,5 @@ def check_and_download(dry_run=False, aerosol_types=None):
             needed_aerosol_types.append(aerosol_type)
 
     # Download
-    download_luts(aerosol_types=needed_aerosol_types, dry_run=dry_run)
+    if needed_aerosol_types:
+        download_luts(aerosol_types=needed_aerosol_types, dry_run=dry_run)

--- a/pyspectral/rayleigh.py
+++ b/pyspectral/rayleigh.py
@@ -349,22 +349,22 @@ def get_reflectance_lut_from_file(lut_filename):
     return azidiff, satellite_zenith_secant, sun_zenith_secant
 
 
-def check_and_download(**kwargs):
-    """
-    Download atm correction LUT tables if they are not up to date already.
+def check_and_download(dry_run=False, aerosol_types=None):
+    """Download atm correction LUT tables if they are not up-to-date already.
 
     Do a check for the version of the atmospheric correction LUTs and attempt
     downloading only if needed.
 
     """
-    aerosol_types = kwargs.get('aerosol_types', AEROSOL_TYPES)
-    dry_run = kwargs.get('dry_run', False)
-
+    aerosol_types = aerosol_types or AEROSOL_TYPES
+    needed_aerosol_types = []
     for aerosol_type in aerosol_types:
         atmcorr = RayleighConfigBaseClass(aerosol_type)
         if atmcorr.lutfiles_version_uptodate:
             LOG.info("Atm correction LUTs, for aerosol distribution %s, already the latest!",
                      aerosol_type)
         else:
-            # Download
-            download_luts(aerosol_type=aerosol_type, dry_run=dry_run)
+            needed_aerosol_types.append(aerosol_type)
+
+    # Download
+    download_luts(aerosol_types=needed_aerosol_types, dry_run=dry_run)

--- a/pyspectral/rsr_reader.py
+++ b/pyspectral/rsr_reader.py
@@ -48,11 +48,15 @@ OSCAR_PLATFORM_NAMES = {'eos-2': 'EOS-Aqua',
 
 
 class RSRDict(dict):
+    """Helper dict-like class to handle multiple names for band keys."""
+
     def __init__(self, instrument=None):
+        """Initialize dict and primary instrument name."""
         self.instrument = instrument
         dict.__init__(self)
 
     def __getitem__(self, key):
+        """Get value either directly or fallback to pre-configured 'standard' names.."""
         try:
             val = dict.__getitem__(self, key)
         except KeyError:
@@ -178,7 +182,6 @@ class RelativeSpectralResponse(RSRDataBaseClass):
 
     def _check_filename_exist(self):
         """Check that the file exist."""
-
         if not os.path.exists(self.filename) or not os.path.isfile(self.filename):
             errmsg = ('pyspectral RSR file does not exist! Filename = ' +
                       str(self.filename))
@@ -334,25 +337,18 @@ class RelativeSpectralResponse(RSRDataBaseClass):
                 self.set_band_central_wavelength_per_detector(h5f, bandname, dname)
 
 
-def check_and_download(**kwargs):
+def check_and_download(dest_dir=None, dry_run=False):
     """Do a check for the version and attempt downloading only if needed."""
-    dry_run = kwargs.get('dry_run', False)
-    dest_dir = kwargs.get('dest_dir', None)
-
     rsr = RSRDataBaseClass()
     if rsr.rsr_data_version_uptodate:
         LOG.info("RSR data already the latest!")
     else:
-        if dest_dir:
-            download_rsr(dest_dir=dest_dir, dry_run=dry_run)
-        else:
-            download_rsr(dry_run=dry_run)
+        download_rsr(dest_dir=dest_dir, dry_run=dry_run)
 
 
 def main():
-    """Main."""
-    modis = RelativeSpectralResponse('EOS-Terra', 'modis')
-    del(modis)
+    """Perform basic sanity check of RSR handling."""
+    RelativeSpectralResponse('EOS-Terra', 'modis')
 
 
 if __name__ == "__main__":

--- a/pyspectral/tests/test_utils.py
+++ b/pyspectral/tests/test_utils.py
@@ -252,7 +252,7 @@ def _create_fake_rsr_tarball_bytes():
     file_obj = BytesIO()
 
     with tarfile.open(mode="w:gz", fileobj=file_obj) as rsr_tar:
-        info = tarfile.TarInfo("PYSPECTRAL_RSR_VERSION")
+        info = tarfile.TarInfo(utils.RSR_DATA_VERSION_FILENAME)
         info.size = len(utils.RSR_DATA_VERSION)
         rsr_tar.addfile(info, BytesIO(utils.RSR_DATA_VERSION.encode("ascii")))
 

--- a/pyspectral/tests/test_utils.py
+++ b/pyspectral/tests/test_utils.py
@@ -341,6 +341,6 @@ def _check_expected_aerosol_files(atypes_to_create, tmp_path):
     for aerosol_type in utils.AEROSOL_TYPES:
         atype_fn = tmp_path / aerosol_type / utils.ATM_CORRECTION_LUT_VERSION[aerosol_type]["filename"]
         if aerosol_type in atypes_to_create:
-            assert os.path.isfile(atype_fn)
+            assert atype_fn.is_file()
         else:
             assert not os.path.isfile(atype_fn)

--- a/pyspectral/tests/test_utils.py
+++ b/pyspectral/tests/test_utils.py
@@ -213,3 +213,17 @@ def test_np2str(input_value, exp_except):
 def test_bytes2string(input_value, exp_result):
     """Test the bytes2string function with different inputs."""
     assert bytes2string(input_value) == exp_result
+
+
+def test_download_rsr():
+    """Test basic usage of the download_rsr function."""
+    with unittest.mock.patch("pyspectral.utils.requests") as requests_mock:
+        utils.download_rsr(dry_run=True)
+    requests_mock.assert_not_called()
+
+
+def test_download_luts():
+    """Test basic usage of the download_luts function."""
+    with unittest.mock.patch("pyspectral.utils.requests") as requests_mock:
+        utils.download_luts(dry_run=True)
+    requests_mock.assert_not_called()

--- a/pyspectral/tests/test_utils.py
+++ b/pyspectral/tests/test_utils.py
@@ -181,74 +181,35 @@ class TestUtils(unittest.TestCase):
         np.testing.assert_allclose(wvl_range, expected_range)
 
 
-def test_np2str_byte_object():
-    """Test the np2str function on a byte object."""
-    # byte object
-    npstring = np.string_('hey')
-    assert np2str(npstring) == 'hey'
+@pytest.mark.parametrize(
+    ("input_value", "exp_except"),
+    [
+        (np.string_("hey"), False),
+        (np.array([np.string_("hey")]), False),
+        (np.array(np.string_("hey")), False),
+        ("hey", False),
+        (np.array([np.string_("hey"), np.string_("hey")]), True),
+        (5, True),
+    ],
+)
+def test_np2str(input_value, exp_except):
+    """Test the np2str function on different inputs."""
+    if exp_except:
+        with pytest.raises(ValueError):
+            np2str(input_value)
+    else:
+        assert np2str(input_value) == "hey"
 
 
-def test_np2str_single_element_array():
-    """Test the np2str function."""
-    # single element numpy array
-    npstring = np.string_('Hej')
-    np_arr = np.array([npstring])
-    assert np2str(np_arr) == 'Hej'
-
-
-def test_np2str_single_element_scalar():
-    """Test the np2str function on a scalar."""
-    # scalar numpy array
-    npstring = np.string_('hej')
-    np_arr = np.array(npstring)
-    assert np2str(np_arr) == 'hej'
-
-
-def test_np2str_multi_element():
-    """Test the np2str function on a multi-element array."""
-    # multi-element array
-    npstring = np.string_('hej')
-    npstring = np.array([npstring, npstring])
-    with pytest.raises(ValueError):
-        _ = np2str(npstring)
-
-
-def test_np2str_scalar():
-    """Test the np2str function inputting a scalar value."""
-    # non-array-non-string
-    with pytest.raises(ValueError):
-        _ = np2str(5)
-
-
-def test_np2str_pure_string():
-    """Test the np2str function inputting a pure string."""
-    # pure string
-    pure_str = 'HEJ'
-    assert np2str(pure_str) is pure_str
-
-
-def test_bytes2string_bytes_string():
-    """Test the bytes2string function inputting a bytes string."""
-    # bytes string
-    pure_str = b'Hello'
-    assert bytes2string(pure_str) == 'Hello'
-
-
-def test_bytes2string_pure_string():
-    """Test the bytes2string function inputting a pure string."""
-    # pure string
-    pure_str = 'Hello'
-    assert bytes2string(pure_str) == 'Hello'
-
-
-def test_bytes2string_numpy_string():
-    """Test the bytes2string function inputting numpy string."""
-    npstring = np.string_('HELLO')
-    assert bytes2string(npstring) == 'HELLO'
-
-
-def test_bytes2string_numpy_string_array():
-    """Test the bytes2string function inputting numpy string array."""
-    npstring = np.string_('HELLO')
-    np_arr = np.array(npstring)
-    assert bytes2string(np_arr) == np_arr
+@pytest.mark.parametrize(
+    ("input_value", "exp_result"),
+    [
+        (b"Hello", "Hello"),
+        ("Hello", "Hello"),
+        (np.string_("Hello"), "Hello"),
+        (np.array(np.string_("Hello")), np.array(np.string_("Hello"))),
+    ]
+)
+def test_bytes2string(input_value, exp_result):
+    """Test the bytes2string function with different inputs."""
+    assert bytes2string(input_value) == exp_result

--- a/pyspectral/tests/test_utils.py
+++ b/pyspectral/tests/test_utils.py
@@ -343,4 +343,4 @@ def _check_expected_aerosol_files(atypes_to_create, tmp_path):
         if aerosol_type in atypes_to_create:
             assert atype_fn.is_file()
         else:
-            assert not os.path.isfile(atype_fn)
+            assert not atype_fn.is_file()

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -330,7 +330,9 @@ def download_luts(aerosol_types=None, dry_run=False, aerosol_type=None):
         LOG.debug('Atmospheric LUT URL = %s', lut_tarball_url)
 
         subdir_path = get_rayleigh_lut_dir(subname)
-        _create_rayleigh_aerosol_subdir(subdir_path, dry_run)
+        LOG.debug('Create directory: %s', subdir_path)
+        if not dry_run:
+            os.makedirs(subdir_path, exist_ok=True)
         if dry_run:
             continue
 
@@ -348,16 +350,6 @@ def _get_aerosol_types(aerosol_types, aerosol_type):
     elif aerosol_types is None:
         aerosol_types = list(HTTPS_RAYLEIGH_LUTS.keys())
     return aerosol_types
-
-
-def _create_rayleigh_aerosol_subdir(subdir_path, dry_run):
-    try:
-        LOG.debug('Create directory: %s', subdir_path)
-        if not dry_run:
-            os.makedirs(subdir_path)
-    except OSError:
-        if not os.path.isdir(subdir_path):
-            raise
 
 
 def _download_tarball_and_extract(tarball_url, local_pathname, extract_dir):

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -116,15 +116,15 @@ ATMOSPHERES = {'subarctic summer': 4, 'subarctic winter': 5,
                'tropical': 8, 'us-standard': 9}
 
 HTTPS_RAYLEIGH_LUTS = {}
-URL_PREFIX = "https://zenodo.org/record/1288441/files/pyspectral_atm_correction_luts"
+LUT_URL_PREFIX = "https://zenodo.org/record/1288441/files/pyspectral_atm_correction_luts"
 for atype in AEROSOL_TYPES:
     name = {'rayleigh_only': 'no_aerosol'}.get(atype, atype)
-    url = "{prefix}_{name}.tgz".format(prefix=URL_PREFIX, name=name)
+    url = "{prefix}_{name}.tgz".format(prefix=LUT_URL_PREFIX, name=name)
     HTTPS_RAYLEIGH_LUTS[atype] = url
 
 
 def get_rayleigh_lut_dir(aerosol_type):
-    """Get the rayleight LUT directory for the specified aerosol type."""
+    """Get the rayleigh LUT directory for the specified aerosol type."""
     conf = get_config()
     local_rayleigh_dir = conf.get('rayleigh_dir')
     return os.path.join(local_rayleigh_dir, aerosol_type)

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ requires = ['docutils>=0.3', 'numpy>=1.5.1', 'scipy>=0.14',
             'appdirs']
 
 dask_extra = ['dask[array]']
-test_requires = ['pyyaml', 'dask[array]', 'xlrd', 'pytest', 'xarray']
+test_requires = ['pyyaml', 'dask[array]', 'xlrd', 'pytest', 'xarray', 'responses']
 
 NAME = 'pyspectral'
 


### PR DESCRIPTION
I was updating some code I have that uses the download functions in pyspectral, but started to get frustrated by lack of docstrings or clear keyword arguments. This PR cleans up docstrings and keyword arguments as well as simplifying some of the logic. It includes one deprecation for the aerosol_type versus aerosol_types keyword argument to be more consistent with the `check_and_download` functions.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
