### PR TITLE
Add support for NOAA-21 VIIRS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2013-2021 Pytroll
+# Copyright (c) 2013-2022 Pytroll
 
 # Author(s):
 
@@ -43,10 +43,8 @@ try:
 except IOError:
     long_description = ''
 
-requires = ['docutils>=0.3', 'numpy>=1.5.1', 'scipy>=0.14',
-            'python-geotiepoints>=1.1.1',
-            'h5py>=2.5', 'requests', 'pyyaml',
-            'appdirs']
+requires = ['docutils>=0.3', 'numpy', 'scipy', 'python-geotiepoints>=1.1.1',
+            'h5py>=2.5', 'requests', 'pyyaml', 'appdirs']
 
 dask_extra = ['dask[array]']
 test_requires = ['pyyaml', 'dask[array]', 'xlrd', 'pytest', 'xarray', 'responses']


### PR DESCRIPTION
This PR adds support for the JPSS-2 (NOAA-21) VIIRS RSR data.
The actual pyspectral formattet hdf5 files are not yet uploaded to zenodo, so the version pointing to the RSR files remains as before. The RSR file version will be updated in another PR. See #155 

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
