### PR TITLE
Fix noaa6 rsr

### DIFF
--- a/CHANGELOG_RSR_DATA.rst
+++ b/CHANGELOG_RSR_DATA.rst
@@ -1,0 +1,59 @@
+Changelog for the Relative Spectral Response data
+=================================================
+
+Version <v1.2.0> (Tue Sep 27 21:08:13 2022)
+-------------------------------------------
+
+ * Added VIIRS RSR for JPSS-2/NOAA-21:
+   Based on the J2_VIIRS_RSR_DAWG_At-Launch_Public_Release_V2_Jul2019.zip
+   The data read are the Detector wise files under J2_VIIRS_Detector_RSR_V2:
+
+   J2_VIIRS_RSR_DNBLGS_Detector_Fused_V2FS.txt
+   J2_VIIRS_RSR_I1_Detector_Fused_V2F.txt
+   J2_VIIRS_RSR_I2_Detector_Fused_V2F.txt
+   J2_VIIRS_RSR_I3_Detector_Fused_V2F.txt
+   J2_VIIRS_RSR_I4_Detector_V2F.txt
+   J2_VIIRS_RSR_I5_Detector_V2F.txt
+   J2_VIIRS_RSR_M10_Detector_Fused_V2F.txt
+   J2_VIIRS_RSR_M11_Detector_V2F.txt
+   J2_VIIRS_RSR_M12_Detector_V2F.txt
+   J2_VIIRS_RSR_M13_Detector_V2F.txt
+   J2_VIIRS_RSR_M14_Detector_V2F.txt
+   J2_VIIRS_RSR_M15_Detector_V2F.txt
+   J2_VIIRS_RSR_M16A_Detector_V2F.txt
+   J2_VIIRS_RSR_M1_Detector_Fused_V2F.txt
+   J2_VIIRS_RSR_M2_Detector_Fused_V2F.txt
+   J2_VIIRS_RSR_M3_Detector_Fused_V2F.txt
+   J2_VIIRS_RSR_M4_Detector_Fused_V2F.txt
+   J2_VIIRS_RSR_M5_Detector_Fused_V2F.txt
+   J2_VIIRS_RSR_M6_Detector_Fused_V2F.txt
+   J2_VIIRS_RSR_M7_Detector_Fused_V2F.txt
+   J2_VIIRS_RSR_M8_Detector_Fused_V2F.txt
+   J2_VIIRS_RSR_M9_Detector_WVCOR_Fused_V2F.txt
+
+   The two files here were not considered:
+   J2_VIIRS_RSR_DNBMGS_Detector_Fused_V2FS.txt
+   J2_VIIRS_RSR_M16B_Detector_V2F.txt
+
+ * Correted errors concerning NOAA-6 channel 1 and 2. These proved to be wrong
+   (a factor of 10 scale error), as the files they were based on were
+   wrong. For AVHRR-1 we have been using the ascii files from NOAA STAR
+   (https://www.star.nesdis.noaa.gov/smcd/spb/fwu/homepage/AVHRR/spec_resp_func/index.html). Example
+   of the start of the file for NOAA-6 channel-1:
+
+   %> cat NOAA_6_A103C001.txt
+      Wavelegth (nm)      Normalized RSF
+         5600.000000            0.071000
+         5700.000000            0.449000
+         5800.000000            0.739000
+         5900.000000            0.813000
+         6000.000000            0.806000
+         6200.000000            0.919000
+         6400.000000            1.000000
+         ...
+
+   Here we have instead used the xls files on which the NOAA-STAR files are based: AVHRR1_SRF_only.xls
+
+   For TIROS-N there seem to be a typo in the wavelengths array for channel-1
+   on TIROS-N: A 640 nm should most likely have been 840 nm. This has been
+   corrected in the hdf5 file.

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -75,10 +75,10 @@ INSTRUMENTS = {'NOAA-19': 'avhrr/3',
                'MTG-I1': 'fci'
                }
 
-HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/6557386/files/pyspectral_rsr_data.tgz"
+HTTP_PYSPECTRAL_RSR = "https://zenodo.org/record/7116653/files/pyspectral_rsr_data.tgz"
 
 RSR_DATA_VERSION_FILENAME = "PYSPECTRAL_RSR_VERSION"
-RSR_DATA_VERSION = "v1.1.0"
+RSR_DATA_VERSION = "v1.2.0"
 
 ATM_CORRECTION_LUT_VERSION = {}
 ATM_CORRECTION_LUT_VERSION['antarctic_aerosol'] = {'version': 'v1.0.1',

--- a/rsr_convert_scripts/avhrr1_rsr.py
+++ b/rsr_convert_scripts/avhrr1_rsr.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2022 Pytroll developers
+#
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Read the NOAA AVHRR/1 relative spectral response functions.
+
+Data from NOAA: AVHRR1_SRF_only.xls
+"""
+
+import os
+from xlrd import open_workbook
+from pyspectral.config import get_config
+from pyspectral.utils import get_central_wave
+import numpy as np
+import pkg_resources
+import logging
+import h5py
+
+
+LOG = logging.getLogger(__name__)
+
+AVHRR_BAND_NAMES = {'avhrr/1': ['ch1', 'ch2', 'ch3', 'ch4']}
+AVHRR1_SATELLITES = ['TIROS-N', 'NOAA-6', 'NOAA-8', 'NOAA-10']
+
+DATA_PATH = pkg_resources.resource_filename('pyspectral', 'data/')
+
+CHANNEL_NAMES = {'A101C001': 'ch1',
+                 'A101C002': 'ch2',
+                 'A101C003': 'ch3',
+                 'A101C004': 'ch4',
+                 'A102C001': 'ch1',
+                 'A102C002': 'ch2',
+                 'A102C003': 'ch3',
+                 'A102C004': 'ch4',
+                 'A103C001': 'ch1',
+                 'A103C002': 'ch2',
+                 'A103C003': 'ch3',
+                 'A103C004': 'ch4',
+                 'A104C001': 'ch1',
+                 'A104C002': 'ch2',
+                 'A104C003': 'ch3',
+                 'A104C004': 'ch4'}
+
+
+class AvhrrRSR():
+    """Container for the NOAA AVHRR-1 RSR data."""
+
+    def __init__(self, wavespace='wavelength'):
+        """Initialize the AVHRR-1 RSR class."""
+        options = get_config()
+
+        self.avhrr_path = options['avhrr/1'].get('path')
+        if not os.path.exists(self.avhrr_path):
+            self.avhrr1_path = os.path.join(
+                DATA_PATH, options['avhrr/1'].get('filename'))
+
+        self.output_dir = options.get('rsr_dir', './')
+
+        self.rsr = {}
+        for satname in AVHRR1_SATELLITES:
+            self.rsr[satname] = {}
+            for chname in AVHRR_BAND_NAMES['avhrr/1']:
+                self.rsr[satname][chname] = {'wavelength': None, 'response': None}
+
+        self._load()
+        self.wavespace = wavespace
+        if wavespace not in ['wavelength', 'wavenumber']:
+            raise AttributeError("wavespace has to be either " +
+                                 "'wavelength' or 'wavenumber'!")
+
+        self.unit = 'micrometer'
+        if wavespace == 'wavenumber':
+            # Convert to wavenumber:
+            self.convert2wavenumber()
+
+    def _load(self, scale=1.0):
+        """Load the AVHRR RSR data for the band requested."""
+        wb_ = open_workbook(self.avhrr_path)
+
+        sheet_names = []
+        for sheet in wb_.sheets():
+            if sheet.name in ['Kleespies Data', ]:
+                print("Skip sheet...")
+                continue
+
+            ch_name = CHANNEL_NAMES.get(sheet.name.strip())
+            if not ch_name:
+                break
+
+            sheet_names.append(sheet.name.strip())
+
+            header = sheet.col_values(0, start_rowx=0, end_rowx=2)
+            platform_name = header[0].strip("# ")
+            unit = header[1].split("Wavelength (")[1].strip(")")
+
+            scale = get_scale_from_unit(unit)
+
+            wvl = sheet.col_values(0, start_rowx=2)
+            is_comment = True
+            idx = 0
+            while is_comment:
+                item = wvl[::-1][idx]
+                if isinstance(item, str):
+                    idx = idx+1
+                else:
+                    break
+
+            ndim = len(wvl) - idx
+            wvl = wvl[0:ndim]
+            response = sheet.col_values(1, start_rowx=2, end_rowx=2+ndim)
+
+            wavelength = np.array(wvl) * scale
+            response = np.array(response)
+
+            self.rsr[platform_name][ch_name]['wavelength'] = wavelength
+            self.rsr[platform_name][ch_name]['response'] = response
+
+
+def get_scale_from_unit(unit):
+    """Get the scaling factor to go from unit to micrometers."""
+    unit2scale = {'Å': 0.0001, 'nm': 0.001}
+    return unit2scale.get(unit)
+
+
+def generate_avhrr1_file(avhrr1, platform_name):
+    """Generate the relative response functions for one AVHRR-1 ensor.
+
+    Format is the pyspectral internal common format.
+    """
+    filename = os.path.join(avhrr1.output_dir, "rsr_avhrr1_{sat}.h5".format(sat=platform_name))
+
+    with h5py.File(filename, "w") as h5f:
+
+        h5f.attrs['description'] = 'Relative Spectral Responses for AVHRR/1'
+        h5f.attrs['platform_name'] = platform_name
+        bandnames = avhrr1.rsr[platform_name].keys()
+        h5f.attrs['band_names'] = [str(key) for key in bandnames]
+
+        for chname in bandnames:
+            grp = h5f.create_group(chname)
+
+            wvl = avhrr1.rsr[platform_name][chname]['wavelength']
+            rsp = avhrr1.rsr[platform_name][chname]['response']
+            grp.attrs['central_wavelength'] = get_central_wave(wvl, rsp)
+            arr = avhrr1.rsr[platform_name][chname]['wavelength']
+            dset = grp.create_dataset('wavelength', arr.shape, dtype='f')
+            dset.attrs['unit'] = 'm'
+            dset.attrs['scale'] = 1e-06
+            dset[...] = arr
+            arr = avhrr1.rsr[platform_name][chname]['response']
+            dset = grp.create_dataset('response', arr.shape, dtype='f')
+            dset[...] = arr
+
+
+def run_avhrr1():
+    """Create the AVHRR-1 relative spectral response files."""
+    avhrr_obj = AvhrrRSR()
+    for platform_name in ["NOAA-10", "NOAA-8", "NOAA-6", "TIROS-N"]:
+        generate_avhrr1_file(avhrr_obj, platform_name)
+
+
+if __name__ == "__main__":
+    run_avhrr1()

--- a/rsr_convert_scripts/avhrr1_rsr.py
+++ b/rsr_convert_scripts/avhrr1_rsr.py
@@ -122,6 +122,10 @@ class AvhrrRSR():
 
             ndim = len(wvl) - idx
             wvl = wvl[0:ndim]
+
+            if platform_name == "TIROS-N":
+                wvl = adjust_typo_avhrr1_srf_only_xls_file(platform_name, wvl)
+
             response = sheet.col_values(1, start_rowx=2, end_rowx=2+ndim)
 
             wavelength = np.array(wvl) * scale
@@ -129,6 +133,15 @@ class AvhrrRSR():
 
             self.rsr[platform_name][ch_name]['wavelength'] = wavelength
             self.rsr[platform_name][ch_name]['response'] = response
+
+
+def adjust_typo_avhrr1_srf_only_xls_file(platform_name, wvl):
+    """Adjust typo in wavelength: 640 should most certainly have been 840 in the AVHRR1_SRF_only.xls."""
+    epsilon = 0.01
+    for idx, wavel in enumerate(wvl[1::]):
+        if wvl[idx] > wavel and abs(wavel-640.0) < epsilon:
+            wvl[idx+1] = 840.0
+    return wvl
 
 
 def get_scale_from_unit(unit):

--- a/rsr_convert_scripts/seviri_rsr.py
+++ b/rsr_convert_scripts/seviri_rsr.py
@@ -2,7 +2,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2013-2018, 2020 Pytroll developers
+# Copyright (c) 2013-2022 Pytroll developers
 #
 # Author(s):
 #
@@ -22,9 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Interface to the SEVIRI spectral response functions for all four MSG
-satellites
-"""
+"""Interface to the SEVIRI spectral response functions for all four MSG satellites."""
 
 import os
 from xlrd import open_workbook
@@ -38,17 +36,14 @@ DATA_PATH = pkg_resources.resource_filename('pyspectral', 'data/')
 
 
 class Seviri(object):
-
-    """Class for Seviri RSR"""
+    """Class for Seviri RSR."""
 
     def __init__(self, wavespace='wavelength'):
         """
-        Read the seviri relative spectral responses for all channels and all
-        MSG satellites.
+        Read the seviri relative spectral responses for all channels and all MSG satellites.
 
         Optional input: 'wavespace'. Equals 'wavelength' (units of micron's) on
         default. Can be 'wavenumber' in which case the unit is in cm-1.
-
         """
         options = get_config()
 
@@ -79,7 +74,7 @@ class Seviri(object):
         self.get_centrals()
 
     def _load(self, filename=None):
-        """Read the SEVIRI rsr data"""
+        """Read the SEVIRI rsr data."""
         if not filename:
             filename = self.seviri_path
 
@@ -161,7 +156,7 @@ class Seviri(object):
             self.rsr[ch_name]['wavelength'] = wvl
 
     def convert2wavenumber(self):
-        """Convert from wavelengths to wavenumber"""
+        """Convert from wavelengths to wavenumber."""
         for chname in self.rsr.keys():
             elems = [k for k in self.rsr[chname].keys()]
             for sat in elems:
@@ -184,8 +179,11 @@ class Seviri(object):
         self.unit = 'cm-1'
 
     def get_centrals(self):
-        """Get the central wavenumbers or central wavelengths of all channels,
-        depending on the given 'wavespace'
+        """Get the central wavenumbers or central wavelengths of all channels.
+
+        The unit (wavelength or wavenumber) depends on the 'wave space' given by
+        the attribute *wavespace*.
+
         """
         result = {}
         for chname in self.rsr.keys():
@@ -213,15 +211,14 @@ class Seviri(object):
 
 
 def get_central_wave(wavl, resp):
-    """Calculate the central wavelength or the central wavenumber,
-    depending on what is input
-    """
+    """Calculate the central wavelength (or the central wavenumber if inputs are wave numbers)."""
     return np.trapz(resp * wavl, wavl) / np.trapz(resp, wavl)
 
 
 def generate_seviri_file(seviri, platform_name):
-    """Generate the pyspectral internal common format relative response
-    function file for one SEVIRI
+    """Generate the relative response function file for one SEVIRI sensor.
+
+    The file format is the pyspectral internal common format.
     """
     import h5py
 
@@ -257,14 +254,9 @@ def generate_seviri_file(seviri, platform_name):
             dset[...] = arr
 
 
-def main():
-    """Main"""
+if __name__ == "__main__":
     sev_obj = Seviri()
 
     for satnum in [8, 9, 10, 11]:
         generate_seviri_file(sev_obj, 'Meteosat-{0:d}'.format(satnum))
         print("Meteosat-{0:d} done...".format(satnum))
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
This PR fixes errors recently discovered in the NOAA-6 AVHRR RSR data, see #155 
It also adds a changelog for the RSR data on Zenodo, and updates to point at the latest upload there, including VIIRS RSR data for NOAA-21. See #156 

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
