### PR TITLE
Fix RSR band name retrieval for unconfigured sensors

### DIFF
--- a/pyspectral/bandnames.py
+++ b/pyspectral/bandnames.py
@@ -195,8 +195,6 @@ BANDNAMES['slstr'] = {'S1': 'ch1',
                       'F2': 'ch8',
                       }
 
-BANDNAMES['mersi-2'] = {str(chan_num): str(chan_num) for chan_num in range(26)}
-
 BANDNAMES['VII'] = {'vii_443': 'ch1',
                     'vii_555': 'ch2',
                     'vii_668': 'ch3',

--- a/pyspectral/bandnames.py
+++ b/pyspectral/bandnames.py
@@ -195,6 +195,8 @@ BANDNAMES['slstr'] = {'S1': 'ch1',
                       'F2': 'ch8',
                       }
 
+BANDNAMES['mersi-2'] = {chan_num: chan_num for chan_num in range(26)}
+
 BANDNAMES['VII'] = {'vii_443': 'ch1',
                     'vii_555': 'ch2',
                     'vii_668': 'ch3',

--- a/pyspectral/bandnames.py
+++ b/pyspectral/bandnames.py
@@ -195,7 +195,7 @@ BANDNAMES['slstr'] = {'S1': 'ch1',
                       'F2': 'ch8',
                       }
 
-BANDNAMES['mersi-2'] = {chan_num: chan_num for chan_num in range(26)}
+BANDNAMES['mersi-2'] = {str(chan_num): str(chan_num) for chan_num in range(26)}
 
 BANDNAMES['VII'] = {'vii_443': 'ch1',
                     'vii_555': 'ch2',

--- a/pyspectral/rsr_reader.py
+++ b/pyspectral/rsr_reader.py
@@ -60,7 +60,7 @@ class RSRDict(dict):
         try:
             val = dict.__getitem__(self, key)
         except KeyError:
-            if key in BANDNAMES[self.instrument]:
+            if self.instrument in BANDNAMES and key in BANDNAMES[self.instrument]:
                 val = dict.__getitem__(self, BANDNAMES[self.instrument][key])
             elif key in BANDNAMES['generic']:
                 val = dict.__getitem__(self, BANDNAMES['generic'][key])

--- a/pyspectral/tests/test_rsr_reader.py
+++ b/pyspectral/tests/test_rsr_reader.py
@@ -449,6 +449,12 @@ class TestPopulateRSRObject(unittest.TestCase):
         with self.assertRaises(KeyError):
             print('d', test_rsr['VIS030'])
 
+    def test_rsr_unconfigured_sensor(self):
+        """Test RSRDict finds generic band conversions when specific sensor is not configured."""
+        test_rsr = RSRDict(instrument="i dont exist")
+        test_rsr["ch1"] = 2
+        assert test_rsr['1'] == 2
+
 
 @pytest.mark.parametrize(
     ("version", "exp_download"),


### PR DESCRIPTION
~This adds the missing configuration for mapping MERSI-2 band names to the names used in the RSR files. It is basically "ruined" by the generic mapping mapping numeric band names to `ch{:d}`. This isn't the case for MERSI-2 which uses the same band name.~

It turns out MERSI-2 does use the `chN` names in the RSR HDF5 files, but since it wasn't configured an `if` statement in the RSR Reader was failing with a KeyError before it was supposed to. This PR should fix this so that the "generic" band names are used as a fallback.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
