### PR TITLE
Revert np.nan_to_num usage on rayleigh correction array

### DIFF
--- a/pyspectral/rayleigh.py
+++ b/pyspectral/rayleigh.py
@@ -267,7 +267,7 @@ class Rayleigh(RayleighConfigBaseClass):
                                              dtype=res.dtype,
                                              chunks=getattr(res, "chunks", None))
 
-        res = np.clip(np.nan_to_num(res), 0, 100)
+        res = np.clip(res, 0, 100)
         if compute:
             res = res.compute()
         return res

--- a/pyspectral/tests/test_rayleigh.py
+++ b/pyspectral/tests/test_rayleigh.py
@@ -44,6 +44,7 @@ TEST_RAYLEIGH_RESULT1 = np.array([10.339923,    8.64748], dtype='float32')
 TEST_RAYLEIGH_RESULT2 = np.array([9.653559, 8.464997], dtype='float32')
 TEST_RAYLEIGH_RESULT3 = np.array([5.488735, 8.533125], dtype='float32')
 TEST_RAYLEIGH_RESULT4 = np.array([0.0,    8.64748], dtype='float32')
+TEST_RAYLEIGH_RESULT5 = np.array([9.653559, np.nan], dtype='float32')
 TEST_RAYLEIGH_RESULT_R1 = np.array([16.66666667, 20.83333333, 25.], dtype='float32')
 TEST_RAYLEIGH_RESULT_R2 = np.array([0., 6.25, 12.5], dtype='float32')
 
@@ -322,6 +323,8 @@ class TestRayleigh:
              TEST_RAYLEIGH_RESULT1),
             (np.array([60., 20.]), np.array([49., 26.]), np.array([140., 130.]), np.array([12., 8.]),
              TEST_RAYLEIGH_RESULT2),
+            (np.array([60., 20.]), np.array([49., 26.]), np.array([140., 130.]), np.array([12., np.nan]),
+             TEST_RAYLEIGH_RESULT5),
         ]
     )
     def test_get_reflectance(self, fake_lut_hdf5, sun_zenith, sat_zenith, azidiff, redband_refl, exp_result):

--- a/pyspectral/tests/test_rayleigh.py
+++ b/pyspectral/tests/test_rayleigh.py
@@ -315,28 +315,23 @@ class TestRayleigh:
         np.testing.assert_allclose(refl_corr2, refl_corr3)
 
     @patch('pyspectral.rayleigh.da', None)
-    def test_get_reflectance(self, fake_lut_hdf5):
+    @pytest.mark.parametrize(
+        ("sun_zenith", "sat_zenith", "azidiff", "redband_refl", "exp_result"),
+        [
+            (np.array([67., 32.]), np.array([45., 18.]), np.array([150., 110.]), np.array([14., 5.]),
+             TEST_RAYLEIGH_RESULT1),
+            (np.array([60., 20.]), np.array([49., 26.]), np.array([140., 130.]), np.array([12., 8.]),
+             TEST_RAYLEIGH_RESULT2),
+        ]
+    )
+    def test_get_reflectance(self, fake_lut_hdf5, sun_zenith, sat_zenith, azidiff, redband_refl, exp_result):
         """Test getting the reflectance correction."""
-        sun_zenith = np.array([67., 32.])
-        sat_zenith = np.array([45., 18.])
-        azidiff = np.array([150., 110.])
-        redband_refl = np.array([14., 5.])
         rayl = _create_rayleigh()
         with mocked_rsr():
             refl_corr = rayl.get_reflectance(
                 sun_zenith, sat_zenith, azidiff, 'ch3', redband_refl)
-        np.testing.assert_allclose(refl_corr, TEST_RAYLEIGH_RESULT1)
-
-        sun_zenith = np.array([60., 20.])
-        sat_zenith = np.array([49., 26.])
-        azidiff = np.array([140., 130.])
-        redband_refl = np.array([12., 8.])
-        with mocked_rsr():
-            refl_corr = rayl.get_reflectance(
-                sun_zenith, sat_zenith, azidiff, 'ch3', redband_refl)
-
         assert isinstance(refl_corr, np.ndarray)
-        np.testing.assert_allclose(refl_corr, TEST_RAYLEIGH_RESULT2)
+        np.testing.assert_allclose(refl_corr, exp_result)
 
     @patch('pyspectral.rayleigh.da', None)
     def test_get_reflectance_no_rsr(self, fake_lut_hdf5):


### PR DESCRIPTION
As discussed on slack, the usage of `np.nan_to_num` that is being changed in this PR was probably originally added with the idea that "if the correction calculations went wrong then we don't want to mask pixels, we just want to *not* correct them". The problem with this logic in some recent real world cases is that it is more "jarring" to see uncorrected pixels next to corrected pixels instead of black/transparent/masked pixels. See this MERSI-2 case where the angles at 1000m resolution do not go as far west as the band data pixels at 250m (for some reason) and this results in a 0 correction for these 5 or so pixels on the left side of the swath:

![image](https://user-images.githubusercontent.com/1828519/194412579-2c3608fb-7b38-42ec-a8c5-200c20b3c5d2.png)

If we use this PR's changes (and the way it was before PR #140) then these pixels are simply masked away as invalid pixels:

![image](https://user-images.githubusercontent.com/1828519/194412769-6a0cb881-e387-4b0c-b0cd-2854a7c53e7f.png)

Note: The gray background in the first image was me playing around with the fill value.

I will work on making an issue to further investigate `np.nan_to_num`'s usage in Rayleigh correction at terminator regions.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
