### PR TITLE
Fix: check_and_download() got an unexpected keyword argument 'aerosol_type'

### DIFF
--- a/bin/download_atm_correction_luts.py
+++ b/bin/download_atm_correction_luts.py
@@ -55,4 +55,4 @@ if __name__ == "__main__":
     else:
         logging_off()
 
-    check_and_download(aerosol_type=aerosol_types, dry_run=dry_run)
+    check_and_download(aerosol_types=aerosol_types, dry_run=dry_run)


### PR DESCRIPTION
Since PR#154, this script has been broken with:
TypeError: check_and_download() got an unexpected
keyword argument 'aerosol_type'

<!-- Describe what your PR does, and why -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
