### PR TITLE
Update for FY-4B

### DIFF
--- a/pyspectral/etc/pyspectral.yaml
+++ b/pyspectral/etc/pyspectral.yaml
@@ -228,6 +228,25 @@ download_from_internet: True
 #     ch13: FY4A_AGRI_SRF_CH13.txt
 #     ch14: FY4A_AGRI_SRF_CH14.txt
 
+
+# FY-4B-agri:
+#     path: D:/rsr/
+#     ch1: FY4B_AGRI_SRF_CH01_Pub.txt
+#     ch2: FY4B_AGRI_SRF_CH02_Pub.txt
+#     ch3: FY4B_AGRI_SRF_CH03_Pub.txt
+#     ch4: FY4B_AGRI_SRF_CH04_Pub.txt
+#     ch5: FY4B_AGRI_SRF_CH05_Pub.txt
+#     ch6: FY4B_AGRI_SRF_CH06_Pub.txt
+#     ch7: FY4B_AGRI_SRF_CH07 & CH08_Pub.txt
+#     ch8: FY4B_AGRI_SRF_CH07 & CH08_Pub.txt
+#     ch9: FY4B_AGRI_SRF_CH09_Pub.txt
+#     ch10: FY4B_AGRI_SRF_CH10_Pub.txt
+#     ch11: FY4B_AGRI_SRF_CH11_Pub.txt
+#     ch12: FY4B_AGRI_SRF_CH12_Pub.txt
+#     ch13: FY4B_AGRI_SRF_CH13_Pub.txt
+#     ch14: FY4B_AGRI_SRF_CH14_Pub.txt
+#     ch15: FY4B_AGRI_SRF_CH15_Pub.txt
+
 #Electro-L-N2-msu-gs:
 #     path: /path/to/rsrs/rtcoef_electro-l_2_msugs_srf/
 #     ch1: rtcoef_electro-l_2_msugs_srf_ch01.txt

--- a/pyspectral/etc/pyspectral.yaml
+++ b/pyspectral/etc/pyspectral.yaml
@@ -211,25 +211,25 @@ download_from_internet: True
 #   ch15: GOES-R_ABI_FM2_SRF_CWG_ch15.txt
 #   ch16: GOES-R_ABI_FM2_SRF_CWG_ch16.txt
 
-# FY-4A-agri:
-#     path: /path/to/original/fy4a/agri/data
-#     ch1: FY4A_AGRI_SRF_CH01.txt
-#     ch2: FY4A_AGRI_SRF_CH02.txt
-#     ch3: FY4A_AGRI_SRF_CH03.txt
-#     ch4: FY4A_AGRI_SRF_CH04.txt
-#     ch5: FY4A_AGRI_SRF_CH05.txt
-#     ch6: FY4A_AGRI_SRF_CH06.txt
-#     ch7: FY4A_AGRI_SRF_CH07.txt
-#     ch8: FY4A_AGRI_SRF_CH08.txt
-#     ch9: FY4A_AGRI_SRF_CH09.txt
-#     ch10: FY4A_AGRI_SRF_CH10.txt
-#     ch11: FY4A_AGRI_SRF_CH11.txt
-#     ch12: FY4A_AGRI_SRF_CH12.txt
-#     ch13: FY4A_AGRI_SRF_CH13.txt
-#     ch14: FY4A_AGRI_SRF_CH14.txt
+#FY-4A-agri:
+#    path: D:/rsr/FY4A/
+#    ch1: FY4A_AGRI_SRF_CH01_Pub.txt
+#    ch2: FY4A_AGRI_SRF_CH02_Pub.txt
+#    ch3: FY4A_AGRI_SRF_CH03_Pub.txt
+#    ch4: FY4A_AGRI_SRF_CH04_Pub.txt
+#    ch5: FY4A_AGRI_SRF_CH05_Pub.txt
+#    ch6: FY4A_AGRI_SRF_CH06_Pub.txt
+#    ch7: FY4A_AGRI_SRF_CH07_CH08_Pub.txt
+#    ch8: FY4A_AGRI_SRF_CH07_CH08_Pub.txt
+#    ch9: FY4A_AGRI_SRF_CH09_Pub.txt
+#    ch10: FY4A_AGRI_SRF_CH10_Pub.txt
+#    ch11: FY4A_AGRI_SRF_CH11_Pub.txt
+#    ch12: FY4A_AGRI_SRF_CH12_Pub.txt
+#    ch13: FY4A_AGRI_SRF_CH13_Pub.txt
+#    ch14: FY4A_AGRI_SRF_CH14_Pub.txt
 
-# FY-4B-agri:
-#     path: D:/rsr/
+#FY-4B-agri:
+#     path: D:/rsr/FY4B/
 #     ch1: FY4B_AGRI_SRF_CH01_Pub.txt
 #     ch2: FY4B_AGRI_SRF_CH02_Pub.txt
 #     ch3: FY4B_AGRI_SRF_CH03_Pub.txt

--- a/pyspectral/etc/pyspectral.yaml
+++ b/pyspectral/etc/pyspectral.yaml
@@ -228,7 +228,6 @@ download_from_internet: True
 #     ch13: FY4A_AGRI_SRF_CH13.txt
 #     ch14: FY4A_AGRI_SRF_CH14.txt
 
-
 # FY-4B-agri:
 #     path: D:/rsr/
 #     ch1: FY4B_AGRI_SRF_CH01_Pub.txt

--- a/pyspectral/rayleigh.py
+++ b/pyspectral/rayleigh.py
@@ -153,7 +153,7 @@ class Rayleigh(RayleighConfigBaseClass):
         # Try to fix instrument naming
         instr = INSTRUMENTS.get(platform_name, sensor)
         if instr != sensor:
-            if type(instr) is list:
+            if isinstance(instr, list):
                 if sensor not in instr:
                     sensor = instr[0]
                     LOG.warning("Inconsistent sensor/satellite input - " +

--- a/pyspectral/rayleigh.py
+++ b/pyspectral/rayleigh.py
@@ -150,12 +150,19 @@ class Rayleigh(RayleighConfigBaseClass):
         self.sensor = sensor
         self.coeff_filename = None
 
-        # Try fix instrument naming
+        # Try to fix instrument naming
         instr = INSTRUMENTS.get(platform_name, sensor)
         if instr != sensor:
-            sensor = instr
-            LOG.warning("Inconsistent sensor/satellite input - " +
-                        "sensor set to %s", sensor)
+            if type(instr) is list:
+                if sensor not in instr:
+                    sensor = instr[0]
+                    print(sensor, instr)
+                    LOG.warning("Inconsistent sensor/satellite input - " +
+                                "sensor set to %s", sensor)
+            else:
+                sensor = instr
+                LOG.warning("Inconsistent sensor/satellite input - " +
+                            "sensor set to %s", sensor)
 
         self.sensor = sensor.replace('/', '')
 

--- a/pyspectral/rayleigh.py
+++ b/pyspectral/rayleigh.py
@@ -156,7 +156,6 @@ class Rayleigh(RayleighConfigBaseClass):
             if type(instr) is list:
                 if sensor not in instr:
                     sensor = instr[0]
-                    print(sensor, instr)
                     LOG.warning("Inconsistent sensor/satellite input - " +
                                 "sensor set to %s", sensor)
             else:

--- a/pyspectral/rayleigh.py
+++ b/pyspectral/rayleigh.py
@@ -155,9 +155,7 @@ class Rayleigh(RayleighConfigBaseClass):
         if instr != sensor:
             if isinstance(instr, list):
                 if sensor not in instr:
-                    sensor = instr[0]
-                    LOG.warning("Inconsistent sensor/satellite input - " +
-                                "sensor set to %s", sensor)
+                    raise ValueError("This satellite has multiple sensors, you must explicitly state which to use.")
             else:
                 sensor = instr
                 LOG.warning("Inconsistent sensor/satellite input - " +

--- a/pyspectral/tests/test_rayleigh.py
+++ b/pyspectral/tests/test_rayleigh.py
@@ -120,8 +120,8 @@ def _create_fake_lut_hdf5_file(base_dir, atm_type) -> str:
     return filename
 
 
-def _create_rayleigh():
-    rayl = rayleigh.Rayleigh('NOAA-20', 'viirs', atmosphere='midlatitude summer')
+def _create_rayleigh(platform='NOAA-20', sensor='VIIRS'):
+    rayl = rayleigh.Rayleigh(platform, sensor, atmosphere='midlatitude summer')
     return rayl
 
 
@@ -279,6 +279,10 @@ class TestRayleigh:
         # Test case where extreme reduction is performed.
         retv = rayleigh.Rayleigh.reduce_rayleigh_highzenith(sun_zenith, in_rayleigh, 30., 90., 1.5)
         np.testing.assert_allclose(retv, TEST_RAYLEIGH_RESULT_R2)
+
+    def test_rayleight_getname(self):
+        """Test logic for Rayleigh instrument selection."""
+        rayl = _create_rayleigh
 
     @patch('pyspectral.rayleigh.da', None)
     def test_get_reflectance_redband_outside_clip(self, fake_lut_hdf5):

--- a/pyspectral/tests/test_rayleigh.py
+++ b/pyspectral/tests/test_rayleigh.py
@@ -283,13 +283,13 @@ class TestRayleigh:
     def test_rayleigh_getname(self):
         """Test logic for Rayleigh instrument selection."""
         rayl = _create_rayleigh(platform='FY-4A')
-        assert(rayl.sensor == 'agri')
+        assert rayl.sensor == 'agri'
         rayl = _create_rayleigh(platform='FY-4B')
-        assert(rayl.sensor == 'agri')
+        assert rayl.sensor == 'agri'
         rayl = _create_rayleigh(platform='FY-4B', sensor='ghi')
-        assert(rayl.sensor == 'ghi')
+        assert rayl.sensor == 'ghi'
         rayl = _create_rayleigh(platform='FY-4B', sensor='nosensor')
-        assert(rayl.sensor == 'agri')
+        assert rayl.sensor == 'agri'
 
     @patch('pyspectral.rayleigh.da', None)
     def test_get_reflectance_redband_outside_clip(self, fake_lut_hdf5):

--- a/pyspectral/tests/test_rayleigh.py
+++ b/pyspectral/tests/test_rayleigh.py
@@ -282,14 +282,21 @@ class TestRayleigh:
 
     def test_rayleigh_getname(self):
         """Test logic for Rayleigh instrument selection."""
-        rayl = _create_rayleigh(platform='FY-4A')
+
+        with pytest.raises(ValueError):
+            _create_rayleigh(platform='FY-4B')
+
+        rayl = _create_rayleigh(platform='FY-4A', sensor='agri')
         assert rayl.sensor == 'agri'
-        rayl = _create_rayleigh(platform='FY-4B')
+
+        rayl = _create_rayleigh(platform='FY-4B', sensor='agri')
         assert rayl.sensor == 'agri'
+
         rayl = _create_rayleigh(platform='FY-4B', sensor='ghi')
         assert rayl.sensor == 'ghi'
-        rayl = _create_rayleigh(platform='FY-4B', sensor='nosensor')
-        assert rayl.sensor == 'agri'
+
+        with pytest.raises(ValueError):
+            _create_rayleigh(platform='FY-4B', sensor='nosensor')
 
     @patch('pyspectral.rayleigh.da', None)
     def test_get_reflectance_redband_outside_clip(self, fake_lut_hdf5):

--- a/pyspectral/tests/test_rayleigh.py
+++ b/pyspectral/tests/test_rayleigh.py
@@ -280,9 +280,16 @@ class TestRayleigh:
         retv = rayleigh.Rayleigh.reduce_rayleigh_highzenith(sun_zenith, in_rayleigh, 30., 90., 1.5)
         np.testing.assert_allclose(retv, TEST_RAYLEIGH_RESULT_R2)
 
-    def test_rayleight_getname(self):
+    def test_rayleigh_getname(self):
         """Test logic for Rayleigh instrument selection."""
-        rayl = _create_rayleigh
+        rayl = _create_rayleigh(platform='FY-4A')
+        assert(rayl.sensor == 'agri')
+        rayl = _create_rayleigh(platform='FY-4B')
+        assert(rayl.sensor == 'agri')
+        rayl = _create_rayleigh(platform='FY-4B', sensor='ghi')
+        assert(rayl.sensor == 'ghi')
+        rayl = _create_rayleigh(platform='FY-4B', sensor='nosensor')
+        assert(rayl.sensor == 'agri')
 
     @patch('pyspectral.rayleigh.da', None)
     def test_get_reflectance_redband_outside_clip(self, fake_lut_hdf5):

--- a/pyspectral/tests/test_utils.py
+++ b/pyspectral/tests/test_utils.py
@@ -33,7 +33,7 @@ import pytest
 import responses
 
 from pyspectral import utils
-from pyspectral.utils import bytes2string, check_and_adjust_instrument_name, np2str
+from pyspectral.utils import bytes2string, check_and_adjust_instrument_name, are_instruments_identical, np2str
 
 TEST_RSR = {'20': {}, }
 TEST_RSR2 = {'20': {}, }
@@ -415,3 +415,28 @@ def test_check_and_adjust_instrument_name_instrument_name_inconsistent(caplog,
 
     log_output = "Inconsistent instrument/satellite input - instrument set to {instr}".format(instr=exp_sensor_name)
     assert log_output in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("platform_name", "input_value_sensor", "exp_sensor_name"),
+    [
+        ('GOES-16', 'abi', 'abi'),
+        ('FY-4B', 'ghi', 'ghi'),
+        ('Meteosat-12', 'fci', 'fci'),
+    ],
+)
+def test_check_and_adjust_instrument_name_correct(platform_name, input_value_sensor, exp_sensor_name):
+    """Check instrument name is not changed if correct."""
+    assert check_and_adjust_instrument_name(platform_name, input_value_sensor) == exp_sensor_name
+
+
+
+def test_are_instruments_identical():
+    """Test that error is raised if non-string is passed to the function."""
+    res = are_instruments_identical('thing1', 'thing1')
+    assert res is True
+    res = are_instruments_identical('thing1', 'thing2')
+    assert res is False
+
+    with pytest.raises(ValueError):
+        are_instruments_identical(['thing1', 'thing3'], 'thing2')

--- a/pyspectral/tests/test_utils.py
+++ b/pyspectral/tests/test_utils.py
@@ -430,7 +430,6 @@ def test_check_and_adjust_instrument_name_correct(platform_name, input_value_sen
     assert check_and_adjust_instrument_name(platform_name, input_value_sensor) == exp_sensor_name
 
 
-
 def test_are_instruments_identical():
     """Test that error is raised if non-string is passed to the function."""
     res = are_instruments_identical('thing1', 'thing1')

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -74,7 +74,7 @@ INSTRUMENTS = {'NOAA-19': 'avhrr/3',
                'Meteosat-9': 'seviri',
                'Meteosat-8': 'seviri',
                'FY-4A': 'agri',
-               'FY-4B': 'agri',
+               'FY-4B': ['agri', 'ghi'],
                'GEO-KOMPSAT-2A': 'ami',
                'MTG-I1': 'fci',
                'Meteosat-12': 'fci',
@@ -536,6 +536,7 @@ def check_and_adjust_instrument_name(platform_name, instrument):
         LOG.warning("Inconsistent instrument/satellite input - instrument set to %s",
                     instrument)
 
+
     return instrument.lower().replace('/', '').replace('-', '')
 
 
@@ -550,5 +551,11 @@ def are_instruments_identical(name1, name2):
         return True
     if name1 == INSTRUMENT_TRANSLATION_DASH2SLASH.get(name2):
         return True
+    if type(name1) is list and type(name2) is str:
+        if name2 in name1:
+            return True
+    if type(name2) is list and type(name1) is str:
+        if name1 in name2:
+            return True
 
     return False

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -532,7 +532,10 @@ def check_and_adjust_instrument_name(platform_name, instrument):
     """
     instr = INSTRUMENTS.get(platform_name, instrument.lower())
     if not are_instruments_identical(instr, instrument.lower()):
-        instrument = instr
+        if type(instr) is list:
+            instrument = instr[0]
+        else:
+            instrument = instr
         LOG.warning("Inconsistent instrument/satellite input - instrument set to %s",
                     instrument)
 

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -532,7 +532,7 @@ def check_and_adjust_instrument_name(platform_name, instrument):
     """
     instr = INSTRUMENTS.get(platform_name, instrument.lower())
     if not are_instruments_identical(instr, instrument.lower()):
-        if type(instr) is list:
+        if isinstance(instr, list):
             instrument = instr[0]
         else:
             instrument = instr
@@ -554,10 +554,10 @@ def are_instruments_identical(name1, name2):
         return True
     if name1 == INSTRUMENT_TRANSLATION_DASH2SLASH.get(name2):
         return True
-    if type(name1) is list and type(name2) is str:
+    if isinstance(name1, list) and isinstance(name2, str):
         if name2 in name1:
             return True
-    if type(name2) is list and type(name1) is str:
+    if isinstance(name2, list) and isinstance(name1, str):
         if name1 in name2:
             return True
 

--- a/rsr_convert_scripts/agri_rsr.py
+++ b/rsr_convert_scripts/agri_rsr.py
@@ -105,7 +105,6 @@ class AGRIRSR(InstrumentRSR):
                                     'response'],
                              skip_header=1)
 
-
         wavelength = data[0] * scale
         response = data[1]
         print(response.shape)
@@ -122,7 +121,7 @@ class AGRIRSR(InstrumentRSR):
 
 def convert_agri():
     """Read original AGRI RSR data and convert to common Pyspectral hdf5 format."""
-    for platform_name in [ "FY-4B"]:
+    for platform_name in ["FY-4B"]:
         tohdf5(AGRIRSR, platform_name, FY4_AGRI_BAND_NAMES)
 
 

--- a/rsr_convert_scripts/agri_rsr.py
+++ b/rsr_convert_scripts/agri_rsr.py
@@ -128,7 +128,7 @@ class AGRIRSR(InstrumentRSR):
 def convert_agri():
     """Read original AGRI RSR data and convert to common Pyspectral hdf5 format."""
     # For FY-4A
-    #tohdf5(AGRIRSR, 'FY-4A', FY4_AGRI_BAND_NAMES[:-1])
+    # tohdf5(AGRIRSR, 'FY-4A', FY4_AGRI_BAND_NAMES[:-1])
 
     # For FY-4B
     tohdf5(AGRIRSR, 'FY-4B', FY4_AGRI_BAND_NAMES)

--- a/rsr_convert_scripts/agri_rsr.py
+++ b/rsr_convert_scripts/agri_rsr.py
@@ -17,9 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Read the FY-4A AGRI relative spectral responses.
+"""Read the FY-4A/B AGRI relative spectral responses.
 
-Data from http://fy4.nsmc.org.cn/portal/cn/fycv/srf.html
+Data from http://satellite.nsmc.org.cn/PortalSite/StaticContent/DocumentDownload.aspx?TypeID=590
 """
 import os
 
@@ -98,13 +98,14 @@ class AGRIRSR(InstrumentRSR):
         Wavelength is given in nanometers.
         """
         data = np.genfromtxt(self.requested_band_filename,
-                             unpack=True,
+                             unpack=True, delimiter='\t',
                              names=['wavelength',
                                     'response'],
-                             skip_header=0)
+                             skip_header=1)
 
-        wavelength = data['wavelength'] * scale
-        response = data['response'] / 100.
+
+        wavelength = data[0] * scale
+        response = data[1] / 100.
 
         self.rsr = {'wavelength': wavelength, 'response': response}
 

--- a/rsr_convert_scripts/agri_rsr.py
+++ b/rsr_convert_scripts/agri_rsr.py
@@ -107,14 +107,12 @@ class AGRIRSR(InstrumentRSR):
 
         wavelength = data[0] * scale
         response = data[1]
-        print(response.shape)
 
         # Cut unneeded points
         pts = np.argwhere(response > 0.001)
 
         wavelength = np.squeeze(wavelength[pts])
         response = np.squeeze(response[pts]) * 100.
-        print(response.shape)
 
         self.rsr = {'wavelength': wavelength, 'response': response}
 

--- a/rsr_convert_scripts/agri_rsr.py
+++ b/rsr_convert_scripts/agri_rsr.py
@@ -71,6 +71,8 @@ class AGRIRSR(InstrumentRSR):
         super(AGRIRSR, self).__init__(bandname, platform_name, FY4_AGRI_BAND_NAMES)
 
         self.instrument = INSTRUMENTS.get(platform_name, 'agri')
+        if type(self.instrument) is list:
+            self.instrument = 'agri'
 
         self._get_options_from_config()
         self._get_bandfilenames()
@@ -105,14 +107,22 @@ class AGRIRSR(InstrumentRSR):
 
 
         wavelength = data[0] * scale
-        response = data[1] / 100.
+        response = data[1]
+        print(response.shape)
+
+        # Cut unneeded points
+        pts = np.argwhere(response > 0.001)
+
+        wavelength = np.squeeze(wavelength[pts])
+        response = np.squeeze(response[pts]) * 100.
+        print(response.shape)
 
         self.rsr = {'wavelength': wavelength, 'response': response}
 
 
 def convert_agri():
     """Read original AGRI RSR data and convert to common Pyspectral hdf5 format."""
-    for platform_name in ["FY-4A", "FY-4B"]:
+    for platform_name in [ "FY-4B"]:
         tohdf5(AGRIRSR, platform_name, FY4_AGRI_BAND_NAMES)
 
 


### PR DESCRIPTION
The FY-4B satellite flies with the AGRI and GHI instruments. This PR Updates pyspectral to support the FY-4B/AGRI relative spectral response functions and also alters the code to accept a satellite with multiple sensors onboard (currently, only one is supported).

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
