### PR TITLE
Bugfix in function doc header

### DIFF
--- a/pyspectral/blackbody.py
+++ b/pyspectral/blackbody.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2013-2022 Pytroll developers
+# Copyright (c) 2013-2023 Pytroll developers
 #
 #
 # This program is free software: you can redistribute it and/or modify
@@ -227,7 +227,7 @@ def blackbody_wn(wavenumber, temp):
             Unit = W/m^2 sr^-1 (m^-1)^-1 = W/m sr^-1
 
             Converting from SI units to mW/m^2 sr^-1 (cm^-1)^-1:
-            1.0 W/m^2 sr^-1 (m^-1)^-1 = 0.1 mW/m^2 sr^-1 (cm^-1)^-1
+            1.0 W/m^2 sr^-1 (m^-1)^-1 = 1.0e5 mW/m^2 sr^-1 (cm^-1)^-1
 
     """
     return planck(wavenumber, temp, wavelength=False)


### PR DESCRIPTION
This is a small bugfix in the description of how to convert from SI units to units often used for Spectral radiance in wave number space. This should have been fixed in #117 where the same error in another doc string was fixed. But it was missed then.

 - [x] Closes #177  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
