### PR TITLE
Fix problem building Readthedocs pages

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@
 version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: doc/source/conf.py
+  configuration: doc/conf.py
   fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF and ePub

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/source/conf.py
+  fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "mambaforge-4.10"
+conda:
+  environment: doc/rtd_environment.yaml

--- a/doc/rtd_environment.yaml
+++ b/doc/rtd_environment.yaml
@@ -1,0 +1,13 @@
+name: readthedocs
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - pip
+  - pytest
+  - sphinx
+  - sphinx_rtd_theme
+  - sphinxcontrib-apidoc
+  - pip:
+    - graphviz
+    - ..  # relative path to the satpy project


### PR DESCRIPTION
Readthedocs stopped building a little while ago. This tries to do this using a RTD yaml config file.

See https://docs.readthedocs.io/en/stable/config-file/v2.html for details

<!-- Describe what your PR does, and why -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
