### PR TITLE
Fix rayleigh not preserving input dtype

### DIFF
--- a/.github/workflows/deploy-sdist.yaml
+++ b/.github/workflows/deploy-sdist.yaml
@@ -15,7 +15,9 @@ jobs:
 
       - name: Create sdist
         shell: bash -l {0}
-        run: python setup.py sdist
+        run: |
+          python -m pip install -q build
+          python -m build -s
 
       - name: Publish package to PyPI
         if: github.event.action == 'published'

--- a/pyspectral/tests/test_rayleigh.py
+++ b/pyspectral/tests/test_rayleigh.py
@@ -158,26 +158,31 @@ class TestRayleighDask:
         np.testing.assert_allclose(refl_corr, TEST_RAYLEIGH_RESULT4)
         assert isinstance(refl_corr, da.Array)
 
-    def test_get_reflectance_dask(self, fake_lut_hdf5):
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_get_reflectance_dask(self, fake_lut_hdf5, dtype):
         """Test getting the reflectance correction with dask inputs."""
-        sun_zenith = da.array([67., 32.])
-        sat_zenith = da.array([45., 18.])
-        azidiff = da.array([150., 110.])
-        redband_refl = da.array([14., 5.])
+        sun_zenith = da.array([67., 32.], dtype=dtype)
+        sat_zenith = da.array([45., 18.], dtype=dtype)
+        azidiff = da.array([150., 110.], dtype=dtype)
+        redband_refl = da.array([14., 5.], dtype=dtype)
         rayl = _create_rayleigh()
         with mocked_rsr():
             refl_corr = rayl.get_reflectance(sun_zenith, sat_zenith, azidiff, 'ch3', redband_refl)
-        np.testing.assert_allclose(refl_corr, TEST_RAYLEIGH_RESULT1)
+        np.testing.assert_allclose(refl_corr, TEST_RAYLEIGH_RESULT1.astype(dtype), atol=4.0e-06)
         assert isinstance(refl_corr, da.Array)
+        assert refl_corr.dtype == dtype  # check that the dask array's dtype is equal
+        assert refl_corr.compute().dtype == dtype  # check that the final numpy array's dtype is equal
 
-        sun_zenith = da.array([60., 20.])
-        sat_zenith = da.array([49., 26.])
-        azidiff = da.array([140., 130.])
-        redband_refl = da.array([12., 8.])
+        sun_zenith = da.array([60., 20.], dtype=dtype)
+        sat_zenith = da.array([49., 26.], dtype=dtype)
+        azidiff = da.array([140., 130.], dtype=dtype)
+        redband_refl = da.array([12., 8.], dtype=dtype)
         with mocked_rsr():
             refl_corr = rayl.get_reflectance(sun_zenith, sat_zenith, azidiff, 'ch3', redband_refl)
-        np.testing.assert_allclose(refl_corr, TEST_RAYLEIGH_RESULT2)
+        np.testing.assert_allclose(refl_corr, TEST_RAYLEIGH_RESULT2.astype(dtype), atol=4.0e-06)
         assert isinstance(refl_corr, da.Array)
+        assert refl_corr.dtype == dtype  # check that the dask array's dtype is equal
+        assert refl_corr.compute().dtype == dtype  # check that the final numpy array's dtype is equal
 
     def test_get_reflectance_numpy_dask(self, fake_lut_hdf5):
         """Test getting the reflectance correction with dask inputs."""


### PR DESCRIPTION
This was discussed briefly on slack, but I noticed that the rayleigh correction in Satpy causes 32-bit float inputs to become 64-bit float outputs after correction. This is mostly due to two things:

1. The LUTs are 64-bit floats
2. The multilinear interpolator has a `dtype` argument that wasn't being specified and defaults to float64.

This PR fixes both and includes an update to the pre-commit config. I also added pyspectral to pre-commit.ci so the pre-commit config should be automatically updated for us.

NOTE: This PR doesn't make a *huge* difference in performance, but it doesn't hurt either. I think the consistency alone is worth it.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

