### PR TITLE
Update the solar spectrum code to use the included reference spectra

### DIFF
--- a/pyspectral/solar.py
+++ b/pyspectral/solar.py
@@ -48,14 +48,20 @@ class SolarIrradianceSpectrum(object):
     in units of W/m^2/micron
     """
 
-    def __init__(self, filename, **options):
+    def __init__(self, filename=TOTAL_IRRADIANCE_SPECTRUM_2000ASTM, **options):
         """Initialize the top of atmosphere solar irradiance spectrum object from file.
 
+        By default, this will use the following spectra:
+        2000 ASTM Standard Extraterrestrial Spectrum Reference E-490-00
+
+        To use a different spectra, specify the `filename` when initialising the class.
+
         Input:
-        filename: Filename of the solar irradiance spectrum
+        filename: Filename of the solar irradiance spectrum (default: 2000 ASTM)
         dlambda:
         Delta wavelength: the step in wavelength defining the resolution on
         which to integrate/convolute.
+
 
         """
         self.wavelength = None

--- a/pyspectral/solar.py
+++ b/pyspectral/solar.py
@@ -2,7 +2,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2013-2022 Pytroll developers
+# Copyright (c) 2013-2023 Pytroll developers
 #
 #
 # This program is free software: you can redistribute it and/or modify
@@ -58,10 +58,16 @@ class SolarIrradianceSpectrum(object):
 
         Input:
         filename: Filename of the solar irradiance spectrum (default: 2000 ASTM)
-        dlambda:
-        Delta wavelength: the step in wavelength defining the resolution on
-        which to integrate/convolute.
-
+        options:
+          dlambda:
+            Delta wavelength: the step in wavelength defining the resolution on
+            which to integrate/convolute.
+            Default is 0.005 if 'wavespace' is 'wavelength' and 2.0 if 'wavenumber'.
+          wavespace:
+            It is possible to specify if the solar irradiance spectrum should
+            be given in terms of wavelength (default) or in terms of
+            wavenumber. If the latter is desired 'wavespace' should be set to
+            'wavenumber'.
 
         """
         self.wavelength = None


### PR DESCRIPTION
At present, the `SolarIrradianceSpectrum` class requires the user to enter the filename to the solar spectra they wish to use.
However, `Pyspectral` comes with a data file containing a solar spectra (2000 ASTM Standard Extraterrestrial Spectrum Reference E-490-00).
This PR updates the class to use the included spectra by default (i.e: In the case that the user does not supply their own via the `filename` argument. I have also updated the `__init__` docstring to make clear that this spectra is used by default.