### PR TITLE
Return 3.x um reflectance with the same dtype as the NIR data

### DIFF
--- a/pyspectral/blackbody.py
+++ b/pyspectral/blackbody.py
@@ -104,12 +104,11 @@ def planck(wave, temperature, wavelength=True):
     wave = _scalar_tuple_list_to_numpy(wave)
 
     if wavelength:
-        const = 2 * H_PLANCK * C_SPEED ** 2
-        nom = const / wave ** 5
-        arg1 = H_PLANCK * C_SPEED / (K_BOLTZMANN * wave)
+        nom = PLANCK_C2 / wave ** 5
+        arg1 = PLANCK_C1 / wave
     else:
-        nom = 2 * H_PLANCK * (C_SPEED ** 2) * (wave ** 3)
-        arg1 = H_PLANCK * C_SPEED * wave / K_BOLTZMANN
+        nom = PLANCK_C2 * wave ** 3
+        arg1 = PLANCK_C1 * wave
 
     with np.errstate(divide='ignore', invalid='ignore'):
         # use dask functions when needed

--- a/pyspectral/blackbody.py
+++ b/pyspectral/blackbody.py
@@ -99,10 +99,6 @@ def planck(wave, temperature, wavelength=True):
         LOG.debug("Using {0} when calculating the Blackbody radiance".format(
             units[(wavelength is True) - 1]))
 
-    temperature = _scalar_tuple_list_to_numpy(temperature)
-    shape = temperature.shape
-    wave = _scalar_tuple_list_to_numpy(wave)
-
     if wavelength:
         nom = PLANCK_C2 / wave ** 5
         arg1 = PLANCK_C1 / wave
@@ -143,29 +139,7 @@ def planck(wave, temperature, wavelength=True):
 
     with np.errstate(over='ignore'):
         denom = np.exp(exp_arg) - 1
-        rad = nom / denom
-        radshape = rad.shape
-        if wave.shape[0] == 1:
-            if temperature.shape[0] == 1:
-                return rad[0, 0]
-            else:
-                return rad[:, 0].reshape(shape)
-        else:
-            if temperature.shape[0] == 1:
-                return rad[0, :]
-            else:
-                if len(shape) == 1:
-                    return rad.reshape((shape[0], radshape[1]))
-                else:
-                    return rad.reshape((shape[0], shape[1], radshape[1]))
-
-
-def _scalar_tuple_list_to_numpy(val):
-    if np.isscalar(val):
-        return np.array([val, ], dtype='float64')
-    if isinstance(val, (list, tuple)):
-        val = np.array(val, dtype='float64')
-    return val
+        return nom / denom
 
 
 def blackbody_wn(wavenumber, temp):

--- a/pyspectral/near_infrared_reflectance.py
+++ b/pyspectral/near_infrared_reflectance.py
@@ -242,12 +242,12 @@ class Calculator(RadTbConverter):
 
         # Assume rsr is in microns!!!
         # FIXME!
-        self._rad3x_t11 = self.tb2radiance(tb_therm, lut=lut)['radiance']
-        thermal_emiss_one = self._rad3x_t11 * self.rsr_integral
-
-        l_nir = self.tb2radiance(tb_nir, lut=lut)['radiance']
+        self._rad3x_t11 = self.tb2radiance(tb_therm, lut=lut)['radiance'].astype(tb_nir.dtype)
+        rsr_integral = tb_therm.dtype.type(self.rsr_integral)
+        thermal_emiss_one = self._rad3x_t11 * rsr_integral
+        l_nir = self.tb2radiance(tb_nir, lut=lut)['radiance'].astype(tb_nir.dtype)
         self._rad3x = l_nir.copy()
-        l_nir *= self.rsr_integral
+        l_nir *= rsr_integral
 
         if thermal_emiss_one.ravel().shape[0] < 10:
             LOG.info('thermal_emiss_one = %s', str(thermal_emiss_one))
@@ -268,7 +268,8 @@ class Calculator(RadTbConverter):
             self.derive_rad39_corr(tb_therm, tbco2)
             LOG.info("CO2 correction applied...")
         else:
-            self._rad3x_correction = 1.0
+            self._rad3x_correction = np.float64(1.0)
+        self._rad3x_correction = self._rad3x_correction.astype(tb_nir.dtype)
 
         corrected_thermal_emiss_one = thermal_emiss_one * self._rad3x_correction
         nomin = l_nir - corrected_thermal_emiss_one

--- a/pyspectral/near_infrared_reflectance.py
+++ b/pyspectral/near_infrared_reflectance.py
@@ -242,10 +242,10 @@ class Calculator(RadTbConverter):
 
         # Assume rsr is in microns!!!
         # FIXME!
-        self._rad3x_t11 = self.tb2radiance(tb_therm, lut=lut)['radiance'].astype(tb_nir.dtype)
+        self._rad3x_t11 = self.tb2radiance(tb_therm, lut=lut)['radiance']
         rsr_integral = tb_therm.dtype.type(self.rsr_integral)
         thermal_emiss_one = self._rad3x_t11 * rsr_integral
-        l_nir = self.tb2radiance(tb_nir, lut=lut)['radiance'].astype(tb_nir.dtype)
+        l_nir = self.tb2radiance(tb_nir, lut=lut)['radiance']
         self._rad3x = l_nir.copy()
         l_nir *= rsr_integral
 

--- a/pyspectral/radiance_tb_conversion.py
+++ b/pyspectral/radiance_tb_conversion.py
@@ -201,15 +201,16 @@ class RadTbConverter(object):
             scale = 1.0
 
         if lut:
+            lut_radiance = lut['radiance'].astype(tb_.dtype)
             ntb = (tb_ * self.tb_scale).astype('int16')
             start = int(lut['tb'][0] * self.tb_scale)
             retv = {}
-            bounds = 0, lut['radiance'].shape[0] - 1
+            bounds = 0, lut_radiance.shape[0] - 1
             index = (ntb - start).clip(bounds[0], bounds[1])
             try:
-                retv['radiance'] = index.map_blocks(self._getitem, lut['radiance'], dtype=lut['radiance'].dtype)
+                retv['radiance'] = index.map_blocks(self._getitem, lut_radiance, dtype=lut_radiance.dtype)
             except AttributeError:
-                retv['radiance'] = lut['radiance'][index]
+                retv['radiance'] = lut_radiance[index]
             try:
                 retv['radiance'] = retv['radiance'].item()
             except (ValueError, AttributeError):

--- a/pyspectral/tests/test_blackbody.py
+++ b/pyspectral/tests/test_blackbody.py
@@ -53,32 +53,32 @@ class CustomScheduler(object):
         return dask.get(dsk, keys, **kwargs)
 
 
-class TestBlackbody(unittest.TestCase):
+class TestBlackbody:
     """Unit testing the blackbody function."""
 
     def test_blackbody(self):
         """Calculate the blackbody radiation from wavelengths and temperatures."""
         wavel = 11. * 1E-6
         black = blackbody((wavel, ), [300., 301])
-        self.assertEqual(black.shape[0], 2)
-        self.assertAlmostEqual(black[0], RAD_11MICRON_300KELVIN)
-        self.assertAlmostEqual(black[1], RAD_11MICRON_301KELVIN)
+        assert black.shape[0] == 2
+        np.testing.assert_almost_equal(black[0], RAD_11MICRON_300KELVIN)
+        np.testing.assert_almost_equal(black[1], RAD_11MICRON_301KELVIN)
 
         temp1 = blackbody_rad2temp(wavel, black[0])
-        self.assertAlmostEqual(temp1, 300.0, 4)
+        np.testing.assert_almost_equal(temp1, 300.0, 4)
         temp2 = blackbody_rad2temp(wavel, black[1])
-        self.assertAlmostEqual(temp2, 301.0, 4)
+        np.testing.assert_almost_equal(temp2, 301.0, 4)
 
         black = blackbody(13. * 1E-6, 200.)
-        self.assertTrue(np.isscalar(black))
+        assert np.isscalar(black)
 
         tb_therm = np.array([[300., 301], [299, 298], [279, 286]])
         black = blackbody((10. * 1E-6, 11.e-6), tb_therm)
-        self.assertIsInstance(black, np.ndarray)
+        assert isinstance(black, np.ndarray)
 
         tb_therm = np.array([[300., 301], [0., 298], [279, 286]])
         black = blackbody((10. * 1E-6, 11.e-6), tb_therm)
-        self.assertIsInstance(black, np.ndarray)
+        assert isinstance(black, np.ndarray)
 
     def test_blackbody_dask(self):
         """Calculate the blackbody radiation from wavelengths and temperatures with dask arrays."""
@@ -87,41 +87,41 @@ class TestBlackbody(unittest.TestCase):
         tb_therm = da.from_array([[300., 301], [299, 298], [279, 286]], chunks=2)
         with dask.config.set(scheduler=CustomScheduler(0)):
             black = blackbody((10. * 1E-6, 11.e-6), tb_therm)
-        self.assertIsInstance(black, da.Array)
+        assert isinstance(black, da.Array)
 
         tb_therm = da.from_array([[300., 301], [0., 298], [279, 286]], chunks=2)
         with dask.config.set(scheduler=CustomScheduler(0)):
             black = blackbody((10. * 1E-6, 11.e-6), tb_therm)
-        self.assertIsInstance(black, da.Array)
+        assert isinstance(black, da.Array)
 
     def test_blackbody_wn(self):
         """Calculate the blackbody radiation from wavenumbers and temperatures."""
         wavenumber = 90909.1  # 11 micron band
         black = blackbody_wn((wavenumber, ), [300., 301])
-        self.assertEqual(black.shape[0], 2)
-        self.assertAlmostEqual(black[0], WN_RAD_11MICRON_300KELVIN)
-        self.assertAlmostEqual(black[1], WN_RAD_11MICRON_301KELVIN)
+        assert black.shape[0] == 2
+        np.testing.assert_almost_equal(black[0], WN_RAD_11MICRON_300KELVIN)
+        np.testing.assert_almost_equal(black[1], WN_RAD_11MICRON_301KELVIN)
 
         temp1 = blackbody_wn_rad2temp(wavenumber, black[0])
-        self.assertAlmostEqual(temp1, 300.0, 4)
+        np.testing.assert_almost_equal(temp1, 300.0, 4)
         temp2 = blackbody_wn_rad2temp(wavenumber, black[1])
-        self.assertAlmostEqual(temp2, 301.0, 4)
+        np.testing.assert_almost_equal(temp2, 301.0, 4)
 
         t__ = blackbody_wn_rad2temp(wavenumber, np.array([0.001, 0.0009]))
         expected = [290.3276916, 283.76115441]
-        self.assertAlmostEqual(t__[0], expected[0])
-        self.assertAlmostEqual(t__[1], expected[1])
+        np.testing.assert_almost_equal(t__[0], expected[0])
+        np.testing.assert_almost_equal(t__[1], expected[1])
 
         radiances = np.array([0.001, 0.0009, 0.0012, 0.0018]).reshape(2, 2)
         t__ = blackbody_wn_rad2temp(wavenumber, radiances)
         expected = np.array([290.3276916, 283.76115441,
                              302.4181330, 333.1414164]).reshape(2, 2)
-        self.assertAlmostEqual(t__[1, 1], expected[1, 1], 5)
-        self.assertAlmostEqual(t__[0, 0], expected[0, 0], 5)
-        self.assertAlmostEqual(t__[0, 1], expected[0, 1], 5)
-        self.assertAlmostEqual(t__[1, 0], expected[1, 0], 5)
+        np.testing.assert_almost_equal(t__[1, 1], expected[1, 1], 5)
+        np.testing.assert_almost_equal(t__[0, 0], expected[0, 0], 5)
+        np.testing.assert_almost_equal(t__[0, 1], expected[0, 1], 5)
+        np.testing.assert_almost_equal(t__[1, 0], expected[1, 0], 5)
 
-        assertNumpyArraysEqual(t__, expected)
+        np.testing.assert_allclose(t__, expected)
 
     def test_blackbody_wn_dask(self):
         """Test that blackbody rad2temp preserves dask arrays."""
@@ -131,13 +131,13 @@ class TestBlackbody(unittest.TestCase):
         radiances = da.from_array([0.001, 0.0009, 0.0012, 0.0018], chunks=2).reshape(2, 2)
         with dask.config.set(scheduler=CustomScheduler(0)):
             t__ = blackbody_wn_rad2temp(wavenumber, radiances)
-        self.assertIsInstance(t__, da.Array)
+        assert isinstance(t__, da.Array)
         t__ = t__.compute()
         expected = np.array([290.3276916, 283.76115441,
                              302.4181330, 333.1414164]).reshape(2, 2)
-        self.assertAlmostEqual(t__[1, 1], expected[1, 1], 5)
-        self.assertAlmostEqual(t__[0, 0], expected[0, 0], 5)
-        self.assertAlmostEqual(t__[0, 1], expected[0, 1], 5)
-        self.assertAlmostEqual(t__[1, 0], expected[1, 0], 5)
+        np.testing.assert_almost_equal(t__[1, 1], expected[1, 1], 5)
+        np.testing.assert_almost_equal(t__[0, 0], expected[0, 0], 5)
+        np.testing.assert_almost_equal(t__[0, 1], expected[0, 1], 5)
+        np.testing.assert_almost_equal(t__[1, 0], expected[1, 0], 5)
 
-        assertNumpyArraysEqual(t__, expected)
+        np.testing.assert_allclose(t__, expected)

--- a/pyspectral/tests/test_blackbody.py
+++ b/pyspectral/tests/test_blackbody.py
@@ -60,14 +60,14 @@ class TestBlackbody:
         """Calculate the blackbody radiation from wavelengths and temperatures."""
         wavel = 11. * 1E-6
         black = blackbody(wavel, 300.)
-        np.testing.assert_almost_equal(black[0], RAD_11MICRON_300KELVIN)
+        assert black == pytest.approx(RAD_11MICRON_300KELVIN)
         temp1 = blackbody_rad2temp(wavel, black)
-        np.testing.assert_almost_equal(temp1, 300.0, 4)
+        assert temp1 == pytest.approx(300.0, 4)
 
         black = blackbody(wavel, 301.)
-        np.testing.assert_almost_equal(black, RAD_11MICRON_301KELVIN)
+        assert black == pytest.approx(RAD_11MICRON_301KELVIN)
         temp2 = blackbody_rad2temp(wavel, black)
-        np.testing.assert_almost_equal(temp2, 301.0, 4)
+        assert temp2 == pytest.approx(301.0, 4)
 
         tb_therm = np.array([[300., 301], [299, 298], [279, 286]])
         black = blackbody(10. * 1E-6, tb_therm)
@@ -94,29 +94,23 @@ class TestBlackbody:
         """Calculate the blackbody radiation from wavenumbers and temperatures."""
         wavenumber = 90909.1  # 11 micron band
         black = blackbody_wn(wavenumber, 300.)
-        np.testing.assert_almost_equal(black, WN_RAD_11MICRON_300KELVIN)
+        assert black == pytest.approx(WN_RAD_11MICRON_300KELVIN)
         temp1 = blackbody_wn_rad2temp(wavenumber, black)
-        np.testing.assert_almost_equal(temp1, 300.0, 4)
+        assert temp1 == pytest.approx(300.0, 4)
 
         black = blackbody_wn(wavenumber, 301.)
-        np.testing.assert_almost_equal(black, WN_RAD_11MICRON_301KELVIN)
+        assert black == pytest.approx(WN_RAD_11MICRON_301KELVIN)
         temp2 = blackbody_wn_rad2temp(wavenumber, black)
-        np.testing.assert_almost_equal(temp2, 301.0, 4)
+        assert temp2 == pytest.approx(301.0, 4)
 
         t__ = blackbody_wn_rad2temp(wavenumber, np.array([0.001, 0.0009]))
         expected = [290.3276916, 283.76115441]
-        np.testing.assert_almost_equal(t__[0], expected[0])
-        np.testing.assert_almost_equal(t__[1], expected[1])
+        np.testing.assert_allclose(t__, expected)
 
         radiances = np.array([0.001, 0.0009, 0.0012, 0.0018]).reshape(2, 2)
         t__ = blackbody_wn_rad2temp(wavenumber, radiances)
         expected = np.array([290.3276916, 283.76115441,
                              302.4181330, 333.1414164]).reshape(2, 2)
-        np.testing.assert_almost_equal(t__[1, 1], expected[1, 1], 5)
-        np.testing.assert_almost_equal(t__[0, 0], expected[0, 0], 5)
-        np.testing.assert_almost_equal(t__[0, 1], expected[0, 1], 5)
-        np.testing.assert_almost_equal(t__[1, 0], expected[1, 0], 5)
-
         np.testing.assert_allclose(t__, expected)
 
     def test_blackbody_wn_dask(self):
@@ -131,9 +125,4 @@ class TestBlackbody:
         t__ = t__.compute()
         expected = np.array([290.3276916, 283.76115441,
                              302.4181330, 333.1414164]).reshape(2, 2)
-        np.testing.assert_almost_equal(t__[1, 1], expected[1, 1], 5)
-        np.testing.assert_almost_equal(t__[0, 0], expected[0, 0], 5)
-        np.testing.assert_almost_equal(t__[0, 1], expected[0, 1], 5)
-        np.testing.assert_almost_equal(t__[1, 0], expected[1, 0], 5)
-
         np.testing.assert_allclose(t__, expected)

--- a/pyspectral/tests/test_blackbody.py
+++ b/pyspectral/tests/test_blackbody.py
@@ -25,7 +25,6 @@ import numpy as np
 import pytest
 
 from pyspectral.blackbody import blackbody, blackbody_rad2temp, blackbody_wn, blackbody_wn_rad2temp
-from pyspectral.tests.unittest_helpers import assertNumpyArraysEqual
 
 RAD_11MICRON_300KELVIN = 9573176.935507433
 RAD_11MICRON_301KELVIN = 9714686.576498277
@@ -91,6 +90,7 @@ class TestBlackbody:
 
     @pytest.mark.parametrize("dtype", (np.float32, np.float64, float))
     def test_blackbody_dask_wave_array(self, dtype):
+        """Test blackbody calculations with dask arrays as inputs."""
         tb_therm = da.array([[300., 301], [0., 298], [279, 286]], dtype=dtype)
         with dask.config.set(scheduler=CustomScheduler(0)):
             black = blackbody(da.array([10. * 1E-6, 11.e-6], dtype=dtype), tb_therm)

--- a/pyspectral/tests/test_blackbody.py
+++ b/pyspectral/tests/test_blackbody.py
@@ -59,32 +59,25 @@ class TestBlackbody:
     def test_blackbody(self):
         """Calculate the blackbody radiation from wavelengths and temperatures."""
         wavel = 11. * 1E-6
-        black = blackbody((wavel, ), [300., 301])
-        assert black.shape[0] == 2
+        black = blackbody(wavel, 300.)
         np.testing.assert_almost_equal(black[0], RAD_11MICRON_300KELVIN)
-        np.testing.assert_almost_equal(black[1], RAD_11MICRON_301KELVIN)
-
-        temp1 = blackbody_rad2temp(wavel, black[0])
+        temp1 = blackbody_rad2temp(wavel, black)
         np.testing.assert_almost_equal(temp1, 300.0, 4)
-        temp2 = blackbody_rad2temp(wavel, black[1])
+
+        black = blackbody(wavel, 301.)
+        np.testing.assert_almost_equal(black, RAD_11MICRON_301KELVIN)
+        temp2 = blackbody_rad2temp(wavel, black)
         np.testing.assert_almost_equal(temp2, 301.0, 4)
 
-        black = blackbody(13. * 1E-6, 200.)
-        assert np.isscalar(black)
-
         tb_therm = np.array([[300., 301], [299, 298], [279, 286]])
-        black = blackbody((10. * 1E-6, 11.e-6), tb_therm)
-        assert isinstance(black, np.ndarray)
-
-        tb_therm = np.array([[300., 301], [0., 298], [279, 286]])
-        black = blackbody((10. * 1E-6, 11.e-6), tb_therm)
+        black = blackbody(10. * 1E-6, tb_therm)
         assert isinstance(black, np.ndarray)
 
     def test_blackbody_dask_wave_tuple(self):
         """Calculate the blackbody radiation from wavelengths and temperatures with dask arrays."""
         tb_therm = da.array([[300., 301], [299, 298], [279, 286]])
         with dask.config.set(scheduler=CustomScheduler(0)):
-            black = blackbody((10. * 1E-6, 11.e-6), tb_therm)
+            black = blackbody(10. * 1E-6, tb_therm)
         assert isinstance(black, da.Array)
         assert black.dtype == np.float64
 
@@ -100,14 +93,14 @@ class TestBlackbody:
     def test_blackbody_wn(self):
         """Calculate the blackbody radiation from wavenumbers and temperatures."""
         wavenumber = 90909.1  # 11 micron band
-        black = blackbody_wn((wavenumber, ), [300., 301])
-        assert black.shape[0] == 2
-        np.testing.assert_almost_equal(black[0], WN_RAD_11MICRON_300KELVIN)
-        np.testing.assert_almost_equal(black[1], WN_RAD_11MICRON_301KELVIN)
-
-        temp1 = blackbody_wn_rad2temp(wavenumber, black[0])
+        black = blackbody_wn(wavenumber, 300.)
+        np.testing.assert_almost_equal(black, WN_RAD_11MICRON_300KELVIN)
+        temp1 = blackbody_wn_rad2temp(wavenumber, black)
         np.testing.assert_almost_equal(temp1, 300.0, 4)
-        temp2 = blackbody_wn_rad2temp(wavenumber, black[1])
+
+        black = blackbody_wn(wavenumber, 301.)
+        np.testing.assert_almost_equal(black, WN_RAD_11MICRON_301KELVIN)
+        temp2 = blackbody_wn_rad2temp(wavenumber, black)
         np.testing.assert_almost_equal(temp2, 301.0, 4)
 
         t__ = blackbody_wn_rad2temp(wavenumber, np.array([0.001, 0.0009]))

--- a/pyspectral/tests/test_rad_tb_conversions.py
+++ b/pyspectral/tests/test_rad_tb_conversions.py
@@ -224,10 +224,10 @@ class RSRTestDataModis(object):
         self.rsr = TEST_RSR
 
 
-class TestSeviriConversions(unittest.TestCase):
+class TestSeviriConversions:
     """Testing the conversions between radiances and brightness temperatures."""
 
-    def setUp(self):
+    def setup_method(self):
         """Set up."""
         with patch('pyspectral.radiance_tb_conversion.RelativeSpectralResponse') as mymock:
             instance = mymock.return_value
@@ -243,7 +243,7 @@ class TestSeviriConversions(unittest.TestCase):
     def test_rad2tb(self):
         """Unit testing the radiance to brightness temperature conversion."""
         res = self.sev1.tb2radiance(TEST_TBS, lut=False)
-        self.assertTrue(np.allclose(TRUE_RADS_SEVIRI, res['radiance']))
+        np.testing.assert_allclose(TRUE_RADS_SEVIRI, res['radiance'], atol=1e-8)
 
     def test_conversion_simple(self):
         """Test the conversion based on the non-linear approximation (SEVIRI).
@@ -256,14 +256,14 @@ class TestSeviriConversions(unittest.TestCase):
         rads = retv['radiance']
         # Units space = wavenumber (cm-1):
         tbs = self.sev2.radiance2tb(rads)
-        self.assertTrue(np.allclose(TEST_TBS, tbs))
+        np.testing.assert_allclose(TEST_TBS, tbs, rtol=1e-6)
 
         np.random.seed()
         tbs1 = 200.0 + np.random.random(50) * 150.0
         retv = self.sev2.tb2radiance(tbs1)
         rads = retv['radiance']
         tbs = self.sev2.radiance2tb(rads)
-        self.assertTrue(np.allclose(tbs1, tbs))
+        np.testing.assert_allclose(tbs1, tbs, rtol=1e-6)
 
     def test_conversions_methods(self):
         """Test the conversion methods.
@@ -279,7 +279,7 @@ class TestSeviriConversions(unittest.TestCase):
 
         rads1 = retv1['radiance']
         rads2 = retv2['radiance']
-        self.assertTrue(np.allclose(rads1, rads2))
+        np.testing.assert_allclose(rads1, rads2, atol=1e-8)
 
 
 class TestRadTbConversions(unittest.TestCase):

--- a/pyspectral/tests/test_rad_tb_conversions.py
+++ b/pyspectral/tests/test_rad_tb_conversions.py
@@ -258,15 +258,15 @@ class TestSeviriConversions:
         rads = retv['radiance']
         # Units space = wavenumber (cm-1):
         tbs = self.sev2.radiance2tb(rads.astype(dtype))
-        assert tbs['radiance'].dtype == dtype
+        assert tbs.dtype == dtype
         np.testing.assert_allclose(TEST_TBS.astype(dtype), tbs, rtol=1e-6)
 
         np.random.seed()
         tbs1 = 200.0 + np.random.random(50) * 150.0
-        retv = self.sev2.tb2radiance(tbs1)
+        retv = self.sev2.tb2radiance(tbs1.astype(dtype))
         rads = retv['radiance']
         tbs = self.sev2.radiance2tb(rads)
-        assert tbs['radiance'].dtype == dtype
+        assert tbs.dtype == dtype
         np.testing.assert_allclose(tbs1, tbs, rtol=1e-6)
 
     @pytest.mark.parametrize("dtype", (np.float32, np.float64, float))

--- a/pyspectral/tests/test_reflectance.py
+++ b/pyspectral/tests/test_reflectance.py
@@ -203,6 +203,13 @@ class TestReflectance(unittest.TestCase):
         refl = refl37.reflectance_from_tbs(sunz, tb3, tb4)
         self.assertTrue(hasattr(refl, 'mask'))
 
+        sunz = np.array([80.], dtype=np.float32)
+        tb3 = np.array([295.], dtype=np.float32)
+        tb4 = np.array([282.], dtype=np.float32)
+        refl = refl37.reflectance_from_tbs(sunz, tb3, tb4)
+        np.testing.assert_allclose(refl, np.array([0.45249779], np.float32))
+        assert refl.dtype == np.float32
+
         try:
             import dask.array as da
             import dask.config

--- a/pyspectral/tests/test_reflectance.py
+++ b/pyspectral/tests/test_reflectance.py
@@ -214,9 +214,9 @@ class TestReflectance(unittest.TestCase):
             import dask.array as da
             import dask.config
 
-            from pyspectral.tests.unittest_helpers import CustomScheduler
+            from pyspectral.tests.unittest_helpers import ComputeCountingScheduler
 
-            with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
+            with dask.config.set(scheduler=ComputeCountingScheduler(max_computes=0)):
                 sunz = da.from_array([50.], chunks=10)
                 tb3 = da.from_array([300.], chunks=10)
                 tb4 = da.from_array([285.], chunks=10)

--- a/pyspectral/tests/test_reflectance.py
+++ b/pyspectral/tests/test_reflectance.py
@@ -205,11 +205,16 @@ class TestReflectance(unittest.TestCase):
 
         try:
             import dask.array as da
-            sunz = da.from_array([50.], chunks=10)
-            tb3 = da.from_array([300.], chunks=10)
-            tb4 = da.from_array([285.], chunks=10)
-            refl = refl37.reflectance_from_tbs(sunz, tb3, tb4)
-            self.assertTrue(hasattr(refl, 'compute'))
+            import dask.config
+
+            from pyspectral.tests.unittest_helpers import CustomScheduler
+
+            with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
+                sunz = da.from_array([50.], chunks=10)
+                tb3 = da.from_array([300.], chunks=10)
+                tb4 = da.from_array([285.], chunks=10)
+                refl = refl37.reflectance_from_tbs(sunz, tb3, tb4)
+                self.assertTrue(hasattr(refl, 'compute'))
         except ImportError:
             pass
 

--- a/pyspectral/tests/unittest_helpers.py
+++ b/pyspectral/tests/unittest_helpers.py
@@ -28,3 +28,21 @@ def assertNumpyArraysEqual(self, other):
         raise AssertionError("Shapes don't match")
     if not np.allclose(self, other):
         raise AssertionError("Elements don't match!")
+
+
+class CustomScheduler(object):
+    """Scheduler raising an exception if data are computed too many times."""
+
+    def __init__(self, max_computes=1):
+        """Set starting and maximum compute counts."""
+        self.max_computes = max_computes
+        self.total_computes = 0
+
+    def __call__(self, dsk, keys, **kwargs):
+        """Compute dask task and keep track of number of times we do so."""
+        import dask
+        self.total_computes += 1
+        if self.total_computes > self.max_computes:
+            raise RuntimeError("Too many dask computations were scheduled: "
+                               "{}".format(self.total_computes))
+        return dask.get(dsk, keys, **kwargs)

--- a/pyspectral/tests/unittest_helpers.py
+++ b/pyspectral/tests/unittest_helpers.py
@@ -30,7 +30,7 @@ def assertNumpyArraysEqual(self, other):
         raise AssertionError("Elements don't match!")
 
 
-class CustomScheduler(object):
+class ComputeCountingScheduler:
     """Scheduler raising an exception if data are computed too many times."""
 
     def __init__(self, max_computes=1):


### PR DESCRIPTION
This PR keeps the `dtype` of the input NIR data for the calculated reflected portion of it. For non-Numpy/Dask inputs `float64` is used.

~The approach is pretty simplistic, I didn't want to start passing `dtype` to the parent class of the `Calculator` (`RadTbConverter`)~


 - [x] Closes #205  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
