### PR TITLE
Update the solar spectrum code to use the included reference spectra

### DIFF
--- a/doc/37_reflectance.rst
+++ b/doc/37_reflectance.rst
@@ -123,9 +123,9 @@ would be:
 where :math:`S(\lambda)` is the spectral solar irradiance.
 
   >>> from pyspectral.rsr_reader import RelativeSpectralResponse
-  >>> from pyspectral.solar import (SolarIrradianceSpectrum, TOTAL_IRRADIANCE_SPECTRUM_2000ASTM)
+  >>> from pyspectral.solar import SolarIrradianceSpectrum
   >>> viirs = RelativeSpectralResponse('Suomi-NPP', 'viirs')
-  >>> solar_irr = SolarIrradianceSpectrum(TOTAL_IRRADIANCE_SPECTRUM_2000ASTM, dlambda=0.005)
+  >>> solar_irr = SolarIrradianceSpectrum(dlambda=0.005)
   >>> sflux = solar_irr.inband_solarflux(viirs.rsr['M12'])
   >>> print(np.round(sflux, 7))
   2.2428119

--- a/doc/rad_definitions.rst
+++ b/doc/rad_definitions.rst
@@ -156,8 +156,8 @@ TOA Solar irradiance and solar constant
 
 First, the TOA solar irradiance in wavelength space:
 
-  >>> from pyspectral.solar import (SolarIrradianceSpectrum, TOTAL_IRRADIANCE_SPECTRUM_2000ASTM)
-  >>> solar_irr = SolarIrradianceSpectrum(TOTAL_IRRADIANCE_SPECTRUM_2000ASTM, dlambda=0.0005) 
+  >>> from pyspectral.solar import SolarIrradianceSpectrum
+  >>> solar_irr = SolarIrradianceSpectrum(dlambda=0.0005)
   >>> print("Solar irradiance = {}".format(round(solar_irr.solar_constant(), 3)))
   Solar irradiance = 1366.091
   >>> solar_irr.plot('/tmp/solar_irradiance.png')
@@ -201,8 +201,8 @@ In python code it may look like this:
    >>> from pyspectral.utils import convert2wavenumber, get_central_wave
    >>> seviri = RelativeSpectralResponse('Meteosat-8', 'seviri')
    >>> rsr, info = convert2wavenumber(seviri.rsr)
-   >>> from pyspectral.solar import (SolarIrradianceSpectrum, TOTAL_IRRADIANCE_SPECTRUM_2000ASTM)
-   >>> solar_irr = SolarIrradianceSpectrum(TOTAL_IRRADIANCE_SPECTRUM_2000ASTM, dlambda=0.0005, wavespace='wavenumber')
+   >>> from pyspectral.solar import SolarIrradianceSpectrum
+   >>> solar_irr = SolarIrradianceSpectrum(dlambda=0.0005, wavespace='wavenumber')
    >>> print("Solar Irradiance (SEVIRI band VIS008) = {sflux:12.6f}".format(sflux=solar_irr.inband_solarflux(rsr['VIS0.8'])))
    Solar Irradiance (SEVIRI band VIS008) = 63767.908405
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -35,9 +35,9 @@ Now, you can work with the data as you wish, make some simple plot for instance:
 A simple use case:
 
   >>> from pyspectral.rsr_reader import RelativeSpectralResponse
-  >>> from pyspectral.solar import (SolarIrradianceSpectrum, TOTAL_IRRADIANCE_SPECTRUM_2000ASTM)
+  >>> from pyspectral.solar import SolarIrradianceSpectrum
   >>> modis = RelativeSpectralResponse('EOS-Aqua', 'modis')
-  >>> solar_irr = SolarIrradianceSpectrum(TOTAL_IRRADIANCE_SPECTRUM_2000ASTM, dlambda=0.005)
+  >>> solar_irr = SolarIrradianceSpectrum(dlambda=0.005)
   >>> sflux = solar_irr.inband_solarflux(modis.rsr['20'])
   >>> print("Solar flux over Band: {sflux}".format(sflux=round(sflux, 6)))
   Solar flux over Band: 2.002928

--- a/pyspectral/near_infrared_reflectance.py
+++ b/pyspectral/near_infrared_reflectance.py
@@ -38,7 +38,7 @@ except ImportError:
 
 from pyspectral.config import get_config
 from pyspectral.radiance_tb_conversion import RadTbConverter
-from pyspectral.solar import TOTAL_IRRADIANCE_SPECTRUM_2000ASTM, SolarIrradianceSpectrum
+from pyspectral.solar import SolarIrradianceSpectrum
 from pyspectral.utils import BANDNAMES, WAVE_LENGTH, get_bandname_from_wavelength
 
 LOG = logging.getLogger(__name__)
@@ -161,8 +161,7 @@ class Calculator(RadTbConverter):
     def _get_solarflux(self):
         """Derive the in-band solar flux from rsr over the Near IR band (3.7 or 3.9 microns)."""
         solar_spectrum = \
-            SolarIrradianceSpectrum(TOTAL_IRRADIANCE_SPECTRUM_2000ASTM,
-                                    dlambda=0.0005,
+            SolarIrradianceSpectrum(dlambda=0.0005,
                                     wavespace=self.wavespace)
         self.solar_flux = solar_spectrum.inband_solarflux(self.rsr[self.bandname])
 

--- a/pyspectral/solar.py
+++ b/pyspectral/solar.py
@@ -48,14 +48,20 @@ class SolarIrradianceSpectrum(object):
     in units of W/m^2/micron
     """
 
-    def __init__(self, filename, **options):
+    def __init__(self, filename=TOTAL_IRRADIANCE_SPECTRUM_2000ASTM, **options):
         """Initialize the top of atmosphere solar irradiance spectrum object from file.
 
+        By default, this will use the following spectra:
+        2000 ASTM Standard Extraterrestrial Spectrum Reference E-490-00
+
+        To use a different spectra, specify the `filename` when initialising the class.
+
         Input:
-        filename: Filename of the solar irradiance spectrum
+        filename: Filename of the solar irradiance spectrum (default: 2000 ASTM)
         dlambda:
         Delta wavelength: the step in wavelength defining the resolution on
         which to integrate/convolute.
+
 
         """
         self.wavelength = None

--- a/pyspectral/solar.py
+++ b/pyspectral/solar.py
@@ -2,7 +2,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2013-2022 Pytroll developers
+# Copyright (c) 2013-2023 Pytroll developers
 #
 #
 # This program is free software: you can redistribute it and/or modify
@@ -58,10 +58,16 @@ class SolarIrradianceSpectrum(object):
 
         Input:
         filename: Filename of the solar irradiance spectrum (default: 2000 ASTM)
-        dlambda:
-        Delta wavelength: the step in wavelength defining the resolution on
-        which to integrate/convolute.
-
+        options:
+          dlambda:
+            Delta wavelength: the step in wavelength defining the resolution on
+            which to integrate/convolute.
+            Default is 0.005 if 'wavespace' is 'wavelength' and 2.0 if 'wavenumber'.
+          wavespace:
+            It is possible to specify if the solar irradiance spectrum should
+            be given in terms of wavelength (default) or in terms of
+            wavenumber. If the latter is desired 'wavespace' should be set to
+            'wavenumber'.
 
         """
         self.wavelength = None

--- a/pyspectral/tests/test_solarflux.py
+++ b/pyspectral/tests/test_solarflux.py
@@ -24,7 +24,7 @@ import unittest
 
 import numpy as np
 
-from pyspectral.solar import TOTAL_IRRADIANCE_SPECTRUM_2000ASTM, SolarIrradianceSpectrum
+from pyspectral.solar import SolarIrradianceSpectrum
 
 TEST_RSR = {}
 TEST_RSR['det-1'] = {}
@@ -59,8 +59,7 @@ class TestSolarflux(unittest.TestCase):
 
     def setUp(self):
         """Set up."""
-        self.solar_irr = SolarIrradianceSpectrum(TOTAL_IRRADIANCE_SPECTRUM_2000ASTM,
-                                                 dlambda=0.005)
+        self.solar_irr = SolarIrradianceSpectrum(dlambda=0.005)
         self.rsr = TEST_RSR
 
     def test_read(self):


### PR DESCRIPTION
Redo of #202 to get around permission issues. This also includes updated docs and tests to take advantage of the default argument added by @simonrp84.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
