### PR TITLE
Add support and RSR converter for the GOCI2 instrument aboard GK-2B

### DIFF
--- a/pyspectral/etc/pyspectral.yaml
+++ b/pyspectral/etc/pyspectral.yaml
@@ -16,7 +16,7 @@
 download_from_internet: True
 
 # Everything below this line should not need to be changed!
-# Changes may be done if you want to change the name of the radiance<->Tb LUT filrnames,
+# Changes may be done if you want to change the name of the radiance<->Tb LUT filenames,
 # or if you want to store those files in different directories dependning on the platform/sensor.
 # Also, if you want to read the original agency specific spectral responses you 
 # can specify their file names and directory paths here.
@@ -50,9 +50,11 @@ download_from_internet: True
 #   path: /home/a000680/data/SpectralResponses/modis/aqua
 #   tb2rad_lut_filename: /path/to/radiance/tb/lut/data/tb2rad_lut_aqua_modis_ir3.7.npz
 
-#DSCOVR-epic:
-#  path: C:/Users/Simon/Downloads/EPIC_Filters_Original_Data.xlsx
+# DSCOVR-epic:
+#  path: /path/to/srf/EPIC_Filters_Original_Data.xlsx
 
+# GK-2B-goci2:
+#  path: /path/to/original/gk2b/goci2/data/GOCI-II_SRF_Measured.csv
 
 # NOAA-20-viirs:
 #   # J1_VIIRS_RSR_M1_Detector_Fused_V2.txt

--- a/rsr_convert_scripts/goci2_rsr.py
+++ b/rsr_convert_scripts/goci2_rsr.py
@@ -22,6 +22,8 @@
 Data from the Korea Ocean Satellite Centre website:
 https://kosc.kiost.ac.kr/index.nm?menuCd=44&lang=en
 
+The direct link to the SRFs is: https://kosc.kiost.ac.kr/upload/GOCI-II_SRF_Measured.csv
+
 """
 
 import logging

--- a/rsr_convert_scripts/goci2_rsr.py
+++ b/rsr_convert_scripts/goci2_rsr.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2024 Pytroll developers
+#
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Read the GeoKompsat-2B / GOCI-II spectral response functions.
+
+Data from the Korea Ocean Satellite Centre website:
+https://kosc.kiost.ac.kr/index.nm?menuCd=44&lang=en
+
+"""
+
+import logging
+import os
+
+import numpy as np
+import pandas as pd
+
+from pyspectral.raw_reader import InstrumentRSR
+from pyspectral.utils import convert2hdf5 as tohdf5
+
+LOG = logging.getLogger(__name__)
+
+GOCI2_BAND_NAMES = {"L380": "B1 (380 nm)",
+                    "L412": "B2 (412 nm)",
+                    "L443": "B3 (443 nm)",
+                    "L490": "B4 (490 nm)",
+                    "L510": "B5 (510 nm)",
+                    "L555": "B6 (555 nm)",
+                    "L620": "B7 (620 nm)",
+                    "L660": "B8 (660 nm)",
+                    "L680": "B9 (680 nm)",
+                    "L709": "B10 (709 nm)",
+                    "L745": "B11 (745 nm)",
+                    "L865": "B12 (865 nm)"
+                   }
+
+#: Default time format
+_DEFAULT_TIME_FORMAT = '%Y-%m-%d %H:%M:%S'
+
+#: Default log format
+_DEFAULT_LOG_FORMAT = '[%(levelname)s: %(asctime)s : %(name)s] %(message)s'
+
+
+class GOCI2RSR(InstrumentRSR):
+    """Container for the GK-2B GOCI2 relative spectral response data."""
+
+    def __init__(self, bandname, platform_name):
+        """Initialize the GOCI2 RSR class."""
+        super(GOCI2RSR, self).__init__(
+            bandname, platform_name, GOCI2_BAND_NAMES.keys())
+
+        self.instrument = 'goci2'
+        self._get_options_from_config()
+
+        LOG.debug("Filename: %s", str(self.path))
+        if os.path.exists(self.path):
+            self._load()
+        else:
+            LOG.warning("Couldn't find an existing file for this band: %s",
+                        str(self.bandname))
+            
+        print(self.path)
+
+        # To be compatible with VIIRS....
+        self.filename = self.requested_band_filename
+
+        self.unit = 'micrometer'
+        self.wavespace = 'wavelength'
+
+    def _load(self, scale=10000.0):
+        """Load the GOCI2 relative spectral responses."""
+        df1 = pd.read_csv(self.path)
+
+        # Column names don't match band names - so we use a dict to find correct
+        # columns. We also need to find the column with the wavelength data.
+        # This is the column before the actual RSR data for each band.
+        col_pos = df1.columns.get_loc(GOCI2_BAND_NAMES[self.bandname])
+        wvl_data = df1.iloc[:, col_pos - 1]
+        srf_data = df1.iloc[:, col_pos]
+
+        # Not all bands have an identical number of RSR points, so we need to
+        # remove NaNs from the data.
+        wvl_data.dropna(inplace=True)
+        srf_data.dropna(inplace=True)
+
+        # Data is in nanometers, so we need to convert to micrometers.
+        # The SRFs should already be normalised to 1, but we normalise here just to be sure.
+        self.rsr = {'wavelength': np.array(wvl_data) / 1000,
+                    'response': np.array(srf_data) / np.nanmax(srf_data)}
+
+
+if __name__ == "__main__":
+    import sys
+    LOG = logging.getLogger('goci2_rsr')
+    handler = logging.StreamHandler(sys.stderr)
+
+    formatter = logging.Formatter(fmt=_DEFAULT_LOG_FORMAT,
+                                  datefmt=_DEFAULT_TIME_FORMAT)
+    handler.setFormatter(formatter)
+    handler.setLevel(logging.DEBUG)
+    LOG.setLevel(logging.DEBUG)
+    LOG.addHandler(handler)
+
+    for platform_name in ['GK-2B', ]:
+        tohdf5(GOCI2RSR, platform_name, list(GOCI2_BAND_NAMES.keys()))

--- a/rsr_convert_scripts/goci2_rsr.py
+++ b/rsr_convert_scripts/goci2_rsr.py
@@ -46,8 +46,7 @@ GOCI2_BAND_NAMES = {"L380": "B1 (380 nm)",
                     "L680": "B9 (680 nm)",
                     "L709": "B10 (709 nm)",
                     "L745": "B11 (745 nm)",
-                    "L865": "B12 (865 nm)"
-                   }
+                    "L865": "B12 (865 nm)"}
 
 #: Default time format
 _DEFAULT_TIME_FORMAT = '%Y-%m-%d %H:%M:%S'
@@ -73,8 +72,6 @@ class GOCI2RSR(InstrumentRSR):
         else:
             LOG.warning("Couldn't find an existing file for this band: %s",
                         str(self.bandname))
-            
-        print(self.path)
 
         # To be compatible with VIIRS....
         self.filename = self.requested_band_filename


### PR DESCRIPTION
This PR adds a script to generate the spectral response function data for the GOCI-2 instrument aboard GeoKompsat-2B.
The RSR raw data has been taken from the official website and the generated data file for pyspectral is available here:
[rsr_goci2_GK-2B.zip](https://github.com/pytroll/pyspectral/files/15196965/rsr_goci2_GK-2B.zip).

I have also edited a string in the YAML file to make it less clear that it was me who added EPIC support ;-)

 - [x] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
