### PR TITLE
Fix scipy 1.14 compatibility and trapz usage

### DIFF
--- a/pyspectral/blackbody.py
+++ b/pyspectral/blackbody.py
@@ -54,6 +54,9 @@ def blackbody_rad2temp(wavelength, radiance):
         The derived temperature in Kelvin.
 
     """
+    if getattr(wavelength, "dtype", None) != radiance.dtype:
+        # avoid a wavelength numpy scalar upcasting radiances (ex. 32-bit to 64-bit float)
+        wavelength = radiance.dtype.type(wavelength)
     with np.errstate(invalid='ignore'):
         return PLANCK_C1 / (wavelength * np.log(PLANCK_C2 / (radiance * wavelength**5) + 1.0))
 

--- a/pyspectral/near_infrared_reflectance.py
+++ b/pyspectral/near_infrared_reflectance.py
@@ -259,7 +259,7 @@ class Calculator(RadTbConverter):
         mu0 = np.cos(np.deg2rad(sunz))
 
         # mu0 = np.where(np.less(mu0, 0.1), 0.1, mu0)
-        self._solar_radiance = self.solar_flux * mu0 / np.pi
+        self._solar_radiance = (self.solar_flux * mu0 / np.pi).astype(tb_nir.dtype)
 
         # CO2 correction to the 3.9 radiance, only if tbs of a co2 band around
         # 13.4 micron is provided:

--- a/pyspectral/radiance_tb_conversion.py
+++ b/pyspectral/radiance_tb_conversion.py
@@ -28,11 +28,15 @@ import logging
 from numbers import Number
 
 import numpy as np
-from scipy import integrate
 
 from pyspectral.blackbody import C_SPEED, H_PLANCK, K_BOLTZMANN, blackbody, blackbody_wn
 from pyspectral.rsr_reader import RelativeSpectralResponse
 from pyspectral.utils import BANDNAMES, WAVE_LENGTH, WAVE_NUMBER, convert2wavenumber, get_bandname_from_wavelength
+
+try:
+    from scipy.integrate import trapezoid
+except ImportError:
+    from scipy.integrate import trapz as trapezoid
 
 LOG = logging.getLogger(__name__)
 
@@ -221,9 +225,9 @@ class RadTbConverter(object):
 
         planck = self.blackbody_function(self.wavelength_or_wavenumber, tb_) * self.response
         if normalized:
-            radiance = integrate.trapz(planck, self.wavelength_or_wavenumber) / self.rsr_integral
+            radiance = trapezoid(planck, self.wavelength_or_wavenumber) / self.rsr_integral
         else:
-            radiance = integrate.trapz(planck, self.wavelength_or_wavenumber)
+            radiance = trapezoid(planck, self.wavelength_or_wavenumber)
 
         return {'radiance': radiance,
                 'unit': unit,

--- a/pyspectral/tests/test_rayleigh.py
+++ b/pyspectral/tests/test_rayleigh.py
@@ -184,25 +184,26 @@ class TestRayleighDask:
         assert refl_corr.dtype == dtype  # check that the dask array's dtype is equal
         assert refl_corr.compute().dtype == dtype  # check that the final numpy array's dtype is equal
 
-    def test_get_reflectance_numpy_dask(self, fake_lut_hdf5):
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_get_reflectance_numpy(self, fake_lut_hdf5, dtype):
         """Test getting the reflectance correction with dask inputs."""
-        sun_zenith = np.array([67., 32.])
-        sat_zenith = np.array([45., 18.])
-        azidiff = np.array([150., 110.])
-        redband_refl = np.array([14., 5.])
+        sun_zenith = np.array([67., 32.], dtype=dtype)
+        sat_zenith = np.array([45., 18.], dtype=dtype)
+        azidiff = np.array([150., 110.], dtype=dtype)
+        redband_refl = np.array([14., 5.], dtype=dtype)
         rayl = _create_rayleigh()
         with mocked_rsr():
             refl_corr = rayl.get_reflectance(sun_zenith, sat_zenith, azidiff, 'ch3', redband_refl)
-        np.testing.assert_allclose(refl_corr, TEST_RAYLEIGH_RESULT1)
+        np.testing.assert_allclose(refl_corr, TEST_RAYLEIGH_RESULT1.astype(dtype), atol=4.0e-06)
         assert isinstance(refl_corr, np.ndarray)
 
-        sun_zenith = np.array([60., 20.])
-        sat_zenith = np.array([49., 26.])
-        azidiff = np.array([140., 130.])
-        redband_refl = np.array([12., 8.])
+        sun_zenith = np.array([60., 20.], dtype=dtype)
+        sat_zenith = np.array([49., 26.], dtype=dtype)
+        azidiff = np.array([140., 130.], dtype=dtype)
+        redband_refl = np.array([12., 8.], dtype=dtype)
         with mocked_rsr():
             refl_corr = rayl.get_reflectance(sun_zenith, sat_zenith, azidiff, 'ch3', redband_refl)
-        np.testing.assert_allclose(refl_corr, TEST_RAYLEIGH_RESULT2)
+        np.testing.assert_allclose(refl_corr, TEST_RAYLEIGH_RESULT2.astype(dtype), atol=4.0e-06)
         assert isinstance(refl_corr, np.ndarray)
 
     def test_get_reflectance_wvl_outside_range(self, fake_lut_hdf5):
@@ -354,6 +355,7 @@ class TestRayleigh:
             refl_corr = rayl.get_reflectance(
                 sun_zenith, sat_zenith, azidiff, 'ch3', redband_refl)
         assert isinstance(refl_corr, np.ndarray)
+        print(refl_corr.dtype)
         np.testing.assert_allclose(refl_corr, exp_result)
 
     @patch('pyspectral.rayleigh.da', None)

--- a/pyspectral/tests/test_rayleigh.py
+++ b/pyspectral/tests/test_rayleigh.py
@@ -334,15 +334,19 @@ class TestRayleigh:
              TEST_RAYLEIGH_RESULT5),
         ]
     )
-    def test_get_reflectance(self, fake_lut_hdf5, sun_zenith, sat_zenith, azidiff, redband_refl, exp_result):
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_get_reflectance(self, fake_lut_hdf5, sun_zenith, sat_zenith, azidiff, redband_refl, exp_result, dtype):
         """Test getting the reflectance correction."""
         rayl = _create_rayleigh()
         with mocked_rsr():
             refl_corr = rayl.get_reflectance(
-                sun_zenith, sat_zenith, azidiff, 'ch3', redband_refl)
+                sun_zenith.astype(dtype),
+                sat_zenith.astype(dtype),
+                azidiff.astype(dtype),
+                'ch3',
+                redband_refl.astype(dtype))
         assert isinstance(refl_corr, np.ndarray)
-        print(refl_corr.dtype)
-        np.testing.assert_allclose(refl_corr, exp_result)
+        np.testing.assert_allclose(refl_corr, exp_result.astype(dtype), atol=4.0e-06)
 
     @patch('pyspectral.rayleigh.da', None)
     def test_get_reflectance_no_rsr(self, fake_lut_hdf5):

--- a/pyspectral/tests/test_utils.py
+++ b/pyspectral/tests/test_utils.py
@@ -225,11 +225,11 @@ class TestUtils(unittest.TestCase):
 @pytest.mark.parametrize(
     ("input_value", "exp_except"),
     [
-        (np.string_("hey"), False),
-        (np.array([np.string_("hey")]), False),
-        (np.array(np.string_("hey")), False),
+        (np.bytes_("hey"), False),
+        (np.array([np.bytes_("hey")]), False),
+        (np.array(np.bytes_("hey")), False),
         ("hey", False),
-        (np.array([np.string_("hey"), np.string_("hey")]), True),
+        (np.array([np.bytes_("hey"), np.bytes_("hey")]), True),
         (5, True),
     ],
 )
@@ -247,8 +247,8 @@ def test_np2str(input_value, exp_except):
     [
         (b"Hello", "Hello"),
         ("Hello", "Hello"),
-        (np.string_("Hello"), "Hello"),
-        (np.array(np.string_("Hello")), np.array(np.string_("Hello"))),
+        (np.bytes_("Hello"), "Hello"),
+        (np.array(np.bytes_("Hello")), np.array(np.bytes_("Hello"))),
     ]
 )
 def test_bytes2string(input_value, exp_result):

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -506,20 +506,23 @@ def convert2str(value):
 
 
 def np2str(value):
-    """Convert an `numpy.string_` to str.
+    """Convert an ``numpy.bytes_`` to str.
+
+    Note: ``numpy.string_`` was deprecated in numpy 2.0 in favor of
+    ``numpy.bytes_``.
 
     Args:
         value (ndarray): scalar or 1-element numpy array to convert
     Raises:
         ValueError: if value is array larger than 1-element or it is not of
-                    type `numpy.string_` or it is not a numpy array
+                    type `numpy.bytes_` or it is not a numpy array
 
     """
     if isinstance(value, str):
         return value
 
     if hasattr(value, 'dtype') and \
-            issubclass(value.dtype.type, (np.str_, np.string_, np.object_)) \
+            issubclass(value.dtype.type, (np.str_, np.bytes_, np.object_)) \
             and value.size == 1:
         value = value.item()
         # python 3 - was scalar numpy array of bytes


### PR DESCRIPTION
CC @arcanerr

The scipy.integrate.trapz function is deprecated. This adds a try/except around importing trapezoid versus trapz. I'm not sure how long we want to keep this workaround as `trapezoid` has been around since at least January of 2023 from what I can tell in git.

 - [x] Closes #227  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
