### PR TITLE
Updated the file name for the FY-3F Mersi-3 RSRs

### DIFF
--- a/pyspectral/rsr_reader.py
+++ b/pyspectral/rsr_reader.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2014-2022 Pytroll developers
+# Copyright (c) 2014-2024 Pytroll developers
 #
 #
 # This program is free software: you can redistribute it and/or modify

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -105,10 +105,10 @@ INSTRUMENT_TRANSLATION_DASH2SLASH = {'avhrr-1': 'avhrr/1',
                                      'avhrr-2': 'avhrr/2',
                                      'avhrr-3': 'avhrr/3'}
 
-HTTP_PYSPECTRAL_RSR = "https://zenodo.org/records/12742887/files/pyspectral_rsr_data.tgz"
+HTTP_PYSPECTRAL_RSR = "https://zenodo.org/records/12743289/files/pyspectral_rsr_data.tgz"
 
 RSR_DATA_VERSION_FILENAME = "PYSPECTRAL_RSR_VERSION"
-RSR_DATA_VERSION = "v1.3.1"
+RSR_DATA_VERSION = "v1.3.2"
 
 ATM_CORRECTION_LUT_VERSION = {}
 ATM_CORRECTION_LUT_VERSION['antarctic_aerosol'] = {'version': 'v1.0.1',

--- a/rsr_convert_scripts/mersi3_rsr.py
+++ b/rsr_convert_scripts/mersi3_rsr.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2018-2022 Pytroll developers
+# Copyright (c) 2018-2022, 2024 Pytroll developers
 #
 #
 # This program is free software: you can redistribute it and/or modify
@@ -28,7 +28,6 @@ import os
 import numpy as np
 
 from pyspectral.raw_reader import InstrumentRSR
-from pyspectral.utils import INSTRUMENTS
 from pyspectral.utils import convert2hdf5 as tohdf5
 
 LOG = logging.getLogger(__name__)
@@ -43,10 +42,10 @@ class Mersi3RSR(InstrumentRSR):
     """Container for the FY3D MERSI-II RSR data."""
 
     def __init__(self, bandname, platform_name):
-        """Initialize the MERSI-2 RSR class."""
+        """Initialize the MERSI-3 RSR class."""
         super(Mersi3RSR, self).__init__(bandname, platform_name, MERSI3_BAND_NAMES)
 
-        self.instrument = INSTRUMENTS.get(platform_name, 'mersi-3')
+        self.instrument = 'mersi3'
 
         self._get_options_from_config()
         self._get_bandfilenames()


### PR DESCRIPTION
The purpose of this PR is to handle the fact that Pyspectral expects the RSR filename for Mersi-3 FY-3F to be `rsr_mersi3_FY-3F.h5` rather than `rsr_mersi-3_FY-3F.h5`

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
