### PR TITLE
Remove deprecated aerosol_type download_luts usage in rayleigh

### DIFF
--- a/pyspectral/rayleigh.py
+++ b/pyspectral/rayleigh.py
@@ -170,7 +170,7 @@ class Rayleigh(RayleighConfigBaseClass):
 
         if not self._lutfiles_version_uptodate and self.do_download:
             LOG.info("Will download from internet...")
-            download_luts(aerosol_type=aerosol_type)
+            download_luts(aerosol_types=[aerosol_type])
 
         if (not os.path.exists(self.reflectance_lut_filename) or
                 not os.path.isfile(self.reflectance_lut_filename)):


### PR DESCRIPTION
Not sure how this usage fell through the cracks, but `download_luts`'s `aerosol_type` kwarg is deprecated. It should be `aerosol_types=[X]`.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
