### PR TITLE
Eliminate division warning

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -20,3 +20,4 @@ The following people have made contributions to this project:
 - [Rolf Helge Pfeiffer](https://github.com/HelgeCPH)
 - [Antonio Valentino](https://github.com/avalentino)
 - [Lu Liu (yukaribbba)](https://github.com/yukaribbba)
+- [Chung-Hsiang Horng (chorng)](https://github.com/chorng)

--- a/pyspectral/blackbody.py
+++ b/pyspectral/blackbody.py
@@ -73,7 +73,7 @@ def blackbody_wn_rad2temp(wavenumber, radiance):
         The derived temperature in Kelvin.
 
     """
-    with np.errstate(invalid='ignore'):
+    with np.errstate(divide='ignore', invalid='ignore'):
         return PLANCK_C1 * wavenumber / np.log((PLANCK_C2 * wavenumber**3) / radiance + 1.0)
 
 

--- a/pyspectral/blackbody.py
+++ b/pyspectral/blackbody.py
@@ -57,7 +57,7 @@ def blackbody_rad2temp(wavelength, radiance):
     if getattr(wavelength, "dtype", None) != radiance.dtype:
         # avoid a wavelength numpy scalar upcasting radiances (ex. 32-bit to 64-bit float)
         wavelength = radiance.dtype.type(wavelength)
-    with np.errstate(invalid='ignore'):
+    with np.errstate(divide='ignore', invalid='ignore'):
         return PLANCK_C1 / (wavelength * np.log(PLANCK_C2 / (radiance * wavelength**5) + 1.0))
 
 

--- a/pyspectral/tests/test_blackbody.py
+++ b/pyspectral/tests/test_blackbody.py
@@ -117,7 +117,7 @@ class TestBlackbody:
         """Test that zero division warning is ignored."""
         with warnings.catch_warnings():
             warnings.simplefilter("error")
-            _ = blackbody_rad2temp(np.ones(1),  np.zeros(1))
-            _ = blackbody_wn_rad2temp(np.ones(1),  np.zeros(1))
-            _ = blackbody(np.ones(2),  np.array([0, 1]))
-            _ = blackbody_wn(np.ones(2),  np.array([0, 1]))
+            _ = blackbody_rad2temp(np.ones(1), np.zeros(1))
+            _ = blackbody_wn_rad2temp(np.ones(1), np.zeros(1))
+            _ = blackbody(np.ones(2), np.array([0, 1]))
+            _ = blackbody_wn(np.ones(2), np.array([0, 1]))

--- a/pyspectral/tests/test_blackbody.py
+++ b/pyspectral/tests/test_blackbody.py
@@ -19,6 +19,8 @@
 
 """Unit testing the Blackbody/Plack radiation derivation."""
 
+import warnings
+
 import dask
 import dask.array as da
 import numpy as np
@@ -110,3 +112,12 @@ class TestBlackbody:
         expected = np.array([290.3276916, 283.76115441,
                              302.4181330, 333.1414164]).reshape(2, 2)
         np.testing.assert_allclose(t__, expected)
+
+    def test_ignore_division_warning(self):
+        """Test that zero division warning is ignored."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _ = blackbody_rad2temp(np.ones(1),  np.zeros(1))
+            _ = blackbody_wn_rad2temp(np.ones(1),  np.zeros(1))
+            _ = blackbody(np.ones(2),  np.array([0, 1]))
+            _ = blackbody_wn(np.ones(2),  np.array([0, 1]))


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
Eliminate the divide-by-zero warning for the `blackbody_wn_rad2temp` function as the `planck` did.

Related issue: #238 
