### PR TITLE
Fix docstring for solar irradiance calc.

### DIFF
--- a/pyspectral/solar.py
+++ b/pyspectral/solar.py
@@ -131,18 +131,21 @@ class SolarIrradianceSpectrum(object):
     def inband_solarflux(self, rsr, scale=1.0, **options):
         """Get the in band solar flux.
 
-        Derive the inband solar flux for a given instrument relative
+        Derive the in-band integrated solar flux for a given instrument relative
         spectral response valid for an earth-sun distance of one AU.
+
+        This is the total solar flux in the band in units of W/m^2.
         """
         return self._band_calculations(rsr, True, scale, **options)
 
     def inband_solarirradiance(self, rsr, scale=1.0, **options):
         """Get the in band solar irradiance.
 
-        Derive the inband solar irradiance for a given instrument relative
+        Derive the in-band spectral solar irradiance for a given instrument relative
         spectral response valid for an earth-sun distance of one AU.
 
-        (Same as the in band solar flux).
+        This is the total solar flux in the band convolved with the
+        spectral response function in units of W/m^2/micron.
         """
         return self._band_calculations(rsr, False, scale, **options)
 


### PR DESCRIPTION
As discussed on slack, the docstrings are confusing for the `inband_solarflux` and `inband_solarirradiance` functions. This PR changes the docstrings to be more clear as to what each function is calculating.
 - [x] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->