### PR TITLE
Fix Zenodo RSR download by adding User-Agent and HTTP checks

### DIFF
--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -411,6 +411,7 @@ HEADERS = {
     "Accept": "*/*",
 }
 
+
 def _download_tarball_and_extract(tarball_url, local_pathname, extract_dir):
     chunk_size = 1024 * 1024  # 1 MB
 

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -407,7 +407,7 @@ def _get_aerosol_types(aerosol_types, aerosol_type):
 
 
 HEADERS = {
-    "User-Agent": "pyspectral/0.12 (+https://github.com/pytroll/pyspectral)",
+    "User-Agent": "pyspectral (+https://github.com/pytroll/pyspectral)",
     "Accept": "*/*",
 }
 

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -406,21 +406,35 @@ def _get_aerosol_types(aerosol_types, aerosol_type):
     return aerosol_types
 
 
+HEADERS = {
+    "User-Agent": "pyspectral/0.12 (+https://github.com/pytroll/pyspectral)",
+    "Accept": "*/*",
+}
+
 def _download_tarball_and_extract(tarball_url, local_pathname, extract_dir):
     chunk_size = 1024 * 1024  # 1 MB
-    response = requests.get(tarball_url)
-    total_size = int(response.headers['content-length'])
+
+    response = requests.get(
+        tarball_url,
+        headers=HEADERS,
+        stream=True,
+        allow_redirects=True,
+    )
+    response.raise_for_status()
+
+    total_size = int(response.headers.get("content-length", 0))
 
     with open(local_pathname, "wb") as handle:
         for data in _tqdm_or_iter(response.iter_content(chunk_size=chunk_size),
                                   total=(int(total_size / chunk_size + 0.5)),
                                   unit='kB'):
-            handle.write(data)
+            if data:
+                handle.write(data)
 
-    tar = tarfile.open(local_pathname)
     tar_kwargs = {} if sys.version_info < (3, 12) else {"filter": "data"}
-    tar.extractall(extract_dir, **tar_kwargs)
-    tar.close()
+    with tarfile.open(local_pathname) as tar:
+        tar.extractall(extract_dir, **tar_kwargs)
+
     os.remove(local_pathname)
 
 


### PR DESCRIPTION
Zenodo seems to block automated downloads that do not provide a proper User-Agent header. As a result, pyspectral may silently download a 403 HTML page instead of the RSR tarball, leading to tarfile read errors.

This commit is meant to provide a minimal fix. It
- adds a proper User-Agent header to the Zenodo download request
- enables streaming downloads
- fails early on HTTP errors instead of extracting invalid files


The issue can be reproduced via Satpy when generating the `day_microphysics` composite for EUMETSAT sensors.

If the pyspectral RSR cache is empty, the first access triggers a download from Zenodo, which currently fails with HTTP 403
when no User-Agent is set.
