### PR TITLE
Fix testing utilities using strings as Path

### DIFF
--- a/pyspectral/testing.py
+++ b/pyspectral/testing.py
@@ -111,7 +111,7 @@ def mock_pyspectral_downloads(
     tmp_path_manager = None
     if tmp_path is None:
         tmp_path_manager = tempfile.TemporaryDirectory(prefix="pyspectral_testing_")
-        tmp_path = tmp_path_manager.name
+        tmp_path = Path(tmp_path_manager.name)
 
     config_options = {}
     config_options["download_from_internet"] = False
@@ -155,7 +155,7 @@ def mock_tb_conversion(
     tmp_path_manager = None
     if tb2rad_dir is None:
         tmp_path_manager = tempfile.TemporaryDirectory(prefix="pyspectral_testing_")
-        tb2rad_dir = tmp_path_manager.name
+        tb2rad_dir = Path(tmp_path_manager.name)
     if rsr_dir is None:
         rsr_dir = tb2rad_dir
 
@@ -224,7 +224,7 @@ def mock_rsr(
     tmp_path_manager = None
     if rsr_dir is None:
         tmp_path_manager = tempfile.TemporaryDirectory(prefix="pyspectral_testing_")
-        rsr_dir = tmp_path_manager.name
+        rsr_dir = Path(tmp_path_manager.name)
     fake_config = {
         "rsr_dir": str(rsr_dir),
         "download_from_internet": False,
@@ -341,7 +341,7 @@ def mock_rayleigh(
     tmp_path_manager = None
     if rayleigh_dir is None:
         tmp_path_manager = tempfile.TemporaryDirectory(prefix="pyspectral_testing_")
-        rayleigh_dir = tmp_path_manager.name
+        rayleigh_dir = Path(tmp_path_manager.name)
 
     if rsr_dir is None:
         rsr_dir = rayleigh_dir

--- a/pyspectral/tests/test_testing.py
+++ b/pyspectral/tests/test_testing.py
@@ -1,0 +1,45 @@
+"""Tests for the testing utilities in pyspectral.testing."""
+
+import numpy as np
+import pytest
+
+from pyspectral.testing import mock_rayleigh, mock_rsr, mock_tb_conversion
+
+
+@pytest.mark.parametrize("use_tmp_path", [False, True])
+def test_tb_conversion(tmp_path, use_tmp_path):
+    """Test basic Calculator mocking and path being provided or not."""
+    from pyspectral.near_infrared_reflectance import Calculator
+
+    tp = tmp_path if use_tmp_path else None
+    with mock_tb_conversion(tb2rad_dir=tp, central_wavelengths={"20": 3.75}):
+        refl37 = Calculator("EOS-Aqua", "modis", "20")
+        expected = 2.001793e-08  # unit = "m" (meter)
+        np.testing.assert_allclose(refl37.rsr_integral, expected)
+
+
+@pytest.mark.parametrize("use_tmp_path", [False, True])
+def test_rsr(tmp_path, use_tmp_path):
+    """Test basic RSR mocking and path being provided or not."""
+    from pyspectral.rsr_reader import RelativeSpectralResponse
+
+    tp = tmp_path if use_tmp_path else None
+    with mock_rsr(rsr_dir=tp):
+        test_rsr = RelativeSpectralResponse("EOS-Aqua", "modis")
+        test_rsr.convert()
+
+
+@pytest.mark.parametrize("use_tmp_path", [False, True])
+def test_rayleigh(tmp_path, use_tmp_path):
+    """Test basic Rayleigh mocking and path being provided or not."""
+    from pyspectral.rayleigh import Rayleigh
+
+    tp = tmp_path if use_tmp_path else None
+    dtype = np.float32
+    sun_zenith = np.array([67.0, 32.0], dtype=dtype)
+    sat_zenith = np.array([45.0, 18.0], dtype=dtype)
+    azidiff = np.array([150.0, 110.0], dtype=dtype)
+    redband_refl = np.array([14.0, 5.0], dtype=dtype)
+    with mock_rayleigh(rayleigh_dir=tp):
+        rayl = Rayleigh("NOAA-20", "VIIRS", atmosphere="midlatitude summer")
+        rayl.get_reflectance(sun_zenith, sat_zenith, azidiff, "I01", redband_refl)


### PR DESCRIPTION
In #262 I added some creation of temporary directories if the user didn't provide one themselves (ex. from `tmp_path` in a pytest test). However, I never cast the location of this temporary directory to a `Path` object so later use of it failed. This PR fixes that and adds some tests specifically for the testing utilities.

Side note: I kind of want to replace the way I create these temporary directories with a decorator on the functions where they check if the user provided a temp dir and if not they create one and use it as a context manager. It makes it a little hard to follow the code but also makes it much cleaner and I can reuse the decorator on all the functions that need it.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
