### PR TITLE
Fix RSR downloads not downloading on-demand

### DIFF
--- a/pyspectral/rsr_reader.py
+++ b/pyspectral/rsr_reader.py
@@ -124,7 +124,6 @@ class _RSRDataBase:
             updated was needed.
 
         """
-        print(self.rsr_data_version, self.rsr_data_version_uptodate, self.do_download)
         if self.rsr_data_version_uptodate:
             return False
 
@@ -153,7 +152,6 @@ class RelativeSpectralResponse(_RSRDataBase):
 
         """
         super(RelativeSpectralResponse, self).__init__()
-        print(filename, platform_name, instrument)
         resolved_filename, resolved_platform_name, resolved_instrument = self._sanitize_inputs(
             filename,
             platform_name,
@@ -166,7 +164,6 @@ class RelativeSpectralResponse(_RSRDataBase):
         self.si_scale = 1e-6  # How to scale the wavelengths to become SI unit
         self._wavespace = WAVE_LENGTH
 
-        print(filename, platform_name, instrument)
         if filename is None:
             # if the user didn't provide a specific file, then make sure we have the most up to date RSRs
             self.download_rsr_updates()

--- a/pyspectral/rsr_reader.py
+++ b/pyspectral/rsr_reader.py
@@ -124,6 +124,7 @@ class _RSRDataBase:
             updated was needed.
 
         """
+        print(self.rsr_data_version, self.rsr_data_version_uptodate, self.do_download)
         if self.rsr_data_version_uptodate:
             return False
 
@@ -152,18 +153,20 @@ class RelativeSpectralResponse(_RSRDataBase):
 
         """
         super(RelativeSpectralResponse, self).__init__()
-        filename, platform_name, instrument = self._sanitize_inputs(
+        print(filename, platform_name, instrument)
+        resolved_filename, resolved_platform_name, resolved_instrument = self._sanitize_inputs(
             filename,
             platform_name,
             instrument,
         )
-        self.filename = filename
-        self.platform_name = platform_name
-        self.instrument = instrument
+        self.filename = resolved_filename
+        self.platform_name = resolved_platform_name
+        self.instrument = resolved_instrument
         self.unit = '1e-6 m'
         self.si_scale = 1e-6  # How to scale the wavelengths to become SI unit
         self._wavespace = WAVE_LENGTH
 
+        print(filename, platform_name, instrument)
         if filename is None:
             # if the user didn't provide a specific file, then make sure we have the most up to date RSRs
             self.download_rsr_updates()

--- a/pyspectral/testing.py
+++ b/pyspectral/testing.py
@@ -208,6 +208,7 @@ def mock_rsr(
             temporary directory is used and deleted on exit of the context manager.
         rsr_data_version: Version number to use for the created fake RSR files.
             By default, the newest/active version number will be used.
+            See :func:`mock_rsr_files` for more details.
         download_from_internet: Set pyspectral configuration value to allow or
             disallow downloads to occur. Defaults to False and relies on mocking
             to make the files seem like they exist. If ``True`` then downloads


### PR DESCRIPTION
Major breaking change in #269. Due to incorrect test driven development ordering, I prevented and guarded against RSR files being downloaded, but there were no tests making sure they would still get downloaded. The main cause was the reuse of the argument names in the RSR reader. This PR splits the usage into "what the user passed" and "what we determined we should use after sanitizing". I also moved more functionality from the RSR tests to the testing utilities.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
