### PR TITLE
Update to latest RSR data on Zenodo

### DIFF
--- a/CHANGELOG_RSR_DATA.rst
+++ b/CHANGELOG_RSR_DATA.rst
@@ -1,6 +1,46 @@
 Changelog for the Relative Spectral Response data
 =================================================
 
+Version v1.5.1 (Mon Mar  9 09:13:07 PM CET 2026)
+
+-------------------------------------------
+
+* Added actual measured (low resolution macro pixel) RSRs for METImage Metop-SG A1
+
+
+Version v1.5.0 (Tue Sep 30 09:53:59 PM CEST 2025)
+
+-------------------------------------------
+
+* Added SLSTR RSRs for Sentinel-3C and -D. Updated with the latest versions from ESA for Sentinel-3A and -B.
+
+
+Version v1.4.1 (Tue Oct 29 03:45:40 PM CET 2024)
+
+-------------------------------------------
+
+ * Added RSRs for Landsat-8 and -9 OLI & TIRS. Original RSR as provided by NASA. Previously we had only Landsat-8 OLI
+
+
+Version v1.4.0 (Tue Sep 24 03:35:15 PM CEST 2024)
+
+-------------------------------------------
+
+ * Added RSRs for Sentinel-2C MSI and updated the MSI RSR for Sentinel 2A & B
+
+
+Version v1.3.2 (Mon Jul 15 12:32:12 PM CEST 2024)
+
+-------------------------------------------
+
+ * Corrected the file name for the RSRs of Mersi-3 onboard FY-3F
+
+
+Version v1.3.1 (Mon Jul 15 11:12:10 AM CEST 2024)
+-------------------------------------------
+
+ * Added SRFs (RSRs) for the Mersi-3 sensor onboard FY-3F
+
 
 Version <v1.3.0> (Fri May  3 04:11:43 PM CEST 2024)
 -------------------------------------------

--- a/pyspectral/utils.py
+++ b/pyspectral/utils.py
@@ -93,10 +93,10 @@ INSTRUMENT_TRANSLATION_DASH2SLASH = {"avhrr-1": "avhrr/1",
                                      "avhrr-2": "avhrr/2",
                                      "avhrr-3": "avhrr/3"}
 
-HTTP_PYSPECTRAL_RSR = "https://zenodo.org/records/14008148/files/pyspectral_rsr_data.tgz"
+HTTP_PYSPECTRAL_RSR = "https://zenodo.org/records/18928854/files/pyspectral_rsr_data.tgz"
 
 RSR_DATA_VERSION_FILENAME = "PYSPECTRAL_RSR_VERSION"
-RSR_DATA_VERSION = "v1.4.1"
+RSR_DATA_VERSION = "v1.5.1"
 
 
 ATM_CORRECTION_LUT_VERSION = {}

--- a/rsr_convert_scripts/metimage_rsr.py
+++ b/rsr_convert_scripts/metimage_rsr.py
@@ -4,7 +4,7 @@ Data from EUMETSAT. Published in March 2026:
 
 https://sftp.eumetsat.int/public/folder/UsCVknVOOkSyCdgpMimJNQ/User-Materials/EPS-SGUP/EPS-SGA1_METIMAGE_SRF.nc
 
-These are the so called low resolution macropixel (=average over all detectors)
+These are the so called low resolution macro pixel (=average over all detectors)
 SRFs. Higher resolution SRFs per detector are available, however, currently
 under export control, so not freely available.
 


### PR DESCRIPTION
In the recently merged PR we forgot to include these updates concerning the latest RSR files on Zenodo. This PR solves this.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
