### PR TITLE
Add metimage high res srfs

### DIFF
--- a/bin/composite_rsr_plot.py
+++ b/bin/composite_rsr_plot.py
@@ -22,21 +22,30 @@ def plot_band(plt_in, band_name, rsr_obj, **kwargs):
         platform_name_in_legend = False
 
     detectors = rsr_obj.rsr[band_name].keys()
-    # for det in detectors:
-    det = sorted(detectors)[0]
-    resp = rsr_obj.rsr[band_name][det]['response']
-    wvl = rsr_obj.rsr[band_name][det]['wavelength']
+    which_dets = kwargs.get('detectors')
 
-    resp = np.ma.masked_less_equal(resp, minimum_response)
-    wvl = np.ma.masked_array(wvl, resp.mask)
-    resp.compressed()
-    wvl.compressed()
+    if not which_dets:
+        detectors = [sorted(detectors)[0]]
+    elif isinstance(which_dets, list):
+        if which_dets[0] != 'all':
+            detectors = which_dets
 
-    if platform_name_in_legend:
-        plt_in.plot(wvl, resp, label='{platform} - {band}'.format(
-            platform=rsr_obj.platform_name, band=band_name))
-    else:
-        plt_in.plot(wvl, resp, label='{band}'.format(band=band_name))
+    for det in detectors:
+        resp = rsr_obj.rsr[band_name][det]['response']
+        wvl = rsr_obj.rsr[band_name][det]['wavelength']
+
+        resp = np.ma.masked_less_equal(resp, minimum_response)
+        wvl = np.ma.masked_array(wvl, resp.mask)
+        resp.compressed()
+        wvl.compressed()
+
+        label = f'{band_name}'
+        if platform_name_in_legend:
+            label = f'{rsr_obj.platform_name} - {band_name}'
+        if which_dets:
+            label = f'{label} / {det}'
+
+        plt_in.plot(wvl, resp, label=label)
 
     return plt_in
 
@@ -85,6 +94,11 @@ def get_arguments():
     group.add_argument("--range", "-r", nargs='*',
                        help="The wavelength range for the plot",
                        default=[None, None], type=float)
+
+    parser.add_argument("--detectors", nargs='*',
+                        help="The detectors to consider ('all' or actual names separated with spaces) " +
+                        "- default is 'det-1'",
+                        default=None, type=str)
 
     parser.add_argument("--exclude_bandnames", nargs='*',
                         default=[],
@@ -162,14 +176,17 @@ if __name__ == "__main__":
             if isinstance(bands, list):
                 for b__ in bands:
                     plt = plot_band(plt, b__, rsr,
-                                    platform_name_in_legend=(not no_platform_name_in_legend))
+                                    platform_name_in_legend=(not no_platform_name_in_legend),
+                                    detectors=args.detectors)
             else:
                 plt = plot_band(plt, bands, rsr,
-                                platform_name_in_legend=(not no_platform_name_in_legend))
+                                platform_name_in_legend=(not no_platform_name_in_legend),
+                                detectors=args.detectors)
 
         elif band:
             plt = plot_band(plt, band, rsr,
-                            platform_name_in_legend=(not no_platform_name_in_legend))
+                            platform_name_in_legend=(not no_platform_name_in_legend),
+                            detectors=args.detectors)
 
         else:
             wvlx = wvlmin
@@ -186,7 +203,8 @@ if __name__ == "__main__":
                 for b__ in bands:
                     if b__ not in excluded_bandnames and b__ not in prev_bands:
                         plt = plot_band(plt, b__, rsr,
-                                        platform_name_in_legend=(not no_platform_name_in_legend))
+                                        platform_name_in_legend=(not no_platform_name_in_legend),
+                                        detectors=args.detectors)
                     prev_bands.append(b__)
 
     if not something2plot:

--- a/rsr_convert_scripts/metimage_hires_rsr.py
+++ b/rsr_convert_scripts/metimage_hires_rsr.py
@@ -1,0 +1,228 @@
+"""Read the MetImage relative spectral response functions.
+
+Data from EUMETSAT. Acquired under export control on May 7, 2026
+
+These are the full resolution SRFs per detector.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+from pyspectral.bandnames import BANDNAMES
+from pyspectral.raw_reader import InstrumentRSR
+from pyspectral.utils import get_central_wave
+
+LOG = logging.getLogger(__name__)
+
+
+METIMAGE_BAND_NAMES_DICT = {BANDNAMES['VII'][k]: k for k in BANDNAMES['VII']}
+METIMAGE_BAND_NAMES = list(METIMAGE_BAND_NAMES_DICT.keys())
+
+METIMAGE_BAND_NAMES_DICT_REVERSE = {v: k for k, v in METIMAGE_BAND_NAMES_DICT.items()}
+
+VISNIR = "VISNIR"
+SMWIR = "SMWIR"
+VLWIR = "VLWIR"
+
+CHANNEL_GROUP_START_NUM = {VISNIR: 0, SMWIR: 7, VLWIR: 14}
+
+
+class ISRFReader:
+    """Reader for the original EUMETSAT METimage SRF data."""
+
+    def __init__(self, filename):
+        """Initialize the class."""
+        self.filename = Path(filename)
+        self._h5 = None
+
+    def __enter__(self):
+        """Instantiate the class, creating the hdf5 file object."""
+        self._h5 = h5py.File(self.filename, "r")
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Exit the class."""
+        self.close()
+
+    def close(self):
+        """Close the object, making sure to close the hdf5 file object."""
+        if self._h5 is not None:
+            self._h5.close()
+            self._h5 = None
+
+    def band_groups(self):
+        """Get the three band/band-group names in the hdf5 file."""
+        return ["VISNIR", "SMWIR", "VLWIR"]
+
+    def wavelength(self, band, start=None, stop=None):
+        """Get the wavelength array."""
+        dset = self._h5[f"{band}_Wavelength"]
+        return dset[start:stop, 0]
+
+    def isrf(self, band, detector=None, channel=None, wl_slice=None):
+        """
+        Return ISRF data lazily sliced from file.
+
+        Dimensions:
+            wavelength, detector, channel
+
+        Parameters
+        ----------
+        band : str
+            "VISNIR", "SMWIR", or "VLWIR"
+        detector : int or None
+            Detector index, 0..23. If None, return all detectors.
+        channel : int or None
+            Channel index. If None, return all channels.
+        wl_slice : slice
+            Wavelength/sample slice.
+        """
+        dset = self._h5[f"{band}_ISRF"]
+
+        det_sel = slice(None) if detector is None else detector
+        ch_sel = slice(None) if channel is None else channel
+
+        if not wl_slice:
+            wl_slice = slice(None)
+
+        return dset[wl_slice, det_sel, ch_sel]
+
+    def shape(self, band):
+        """Get the shape of the band group dataset from the hdf5 object."""
+        return self._h5[f"{band}_ISRF"].shape
+
+
+def get_groupname_from_bandname(band):
+    """Get band group name in hdf5 file from band (channel) name."""
+    groupname = "VLWIR"
+    wv = int(band.split("_")[-1])
+    if wv > 6000:
+        groupname = "VLWIR"
+    elif wv > 1000:
+        groupname = "SMWIR"
+    else:
+        groupname = "VISNIR"
+    return groupname
+
+
+class MetImageRSR(InstrumentRSR):
+    """Container for the EPS-SG MetImage RSR data."""
+
+    def __init__(self, bandname, platform_name):
+        """Initialize the class."""
+        super(MetImageRSR, self).__init__(
+            bandname, platform_name, list(METIMAGE_BAND_NAMES))
+
+        self.instrument = 'metimage'
+        self._get_options_from_config()
+
+        LOG.debug(f'Filename: {str(self.path)}')
+        if self.path.exists():
+            self.requested_band_filename = self.path
+            self.nc_band_name = METIMAGE_BAND_NAMES_DICT[bandname]
+            self.group_name = get_groupname_from_bandname(METIMAGE_BAND_NAMES_DICT[bandname])
+            self._load(scale=1e6)
+
+        else:
+            LOG.warning("Couldn't find an existing file for this band: %s",
+                        str(self.bandname))
+
+        # To be compatible with VIIRS....
+        self.filename = self.requested_band_filename
+        self.unit = 'micrometer'
+        self.wavespace = 'wavelength'
+
+    def _load(self, scale=1.0):
+        """Load the METimage relative spectral responses."""
+        LOG.debug(f'File: {str(self.requested_band_filename)}')
+        threshold_response = 0.001
+
+        ch_number = METIMAGE_BAND_NAMES.index(METIMAGE_BAND_NAMES_DICT_REVERSE[self.nc_band_name]) - \
+            CHANNEL_GROUP_START_NUM.get(self.group_name)
+
+        with ISRFReader(self.requested_band_filename) as r:
+            shape = r.shape(self.group_name)
+            num_detectors = shape[1]
+            wvl = r.wavelength(self.group_name) * scale
+
+            detectors = {}
+            for detnum in range(num_detectors):
+                resp = r.isrf(self.group_name, detector=detnum, channel=ch_number)
+                max_resp = resp.max()
+                resp = resp/max_resp
+                detectors[f'det-{detnum+1}'] = {'wavelength': wvl[resp > threshold_response],
+                                                'response': resp[resp > threshold_response]}
+
+            self.rsr = detectors
+
+
+def generate_metimage_file(platform_name):
+    """Retrieve original RSR data and convert to internal hdf5 format."""
+    bandnames = METIMAGE_BAND_NAMES
+    instr = MetImageRSR(bandnames[0], platform_name)
+    instr_name = instr.instrument.replace('/', '')
+    filename = os.path.join(instr.output_dir,
+                            "rsr_{0}_{1}.h5".format(instr_name,
+                                                    platform_name))
+
+    with h5py.File(filename, "w") as h5f:
+        h5f.attrs['description'] = ('Relative Spectral Responses for ' +
+                                    instr.instrument.upper())
+        h5f.attrs['platform_name'] = platform_name
+        h5f.attrs['band_names'] = bandnames
+
+        for chname in bandnames:
+            metimage = MetImageRSR(chname, platform_name)
+            grp = h5f.create_group(chname)
+            grp.attrs['number_of_detectors'] = len(metimage.rsr.keys())
+
+            # Loop over each detector to check if the sampling wavelengths are
+            # identical:
+            det_names = list(metimage.rsr.keys())
+            wvl = metimage.rsr[det_names[0]]['wavelength']
+            wvl, idx = np.unique(wvl, return_index=True)
+            wvl_is_constant = True
+            for det in det_names[1:]:
+                det_wvl = np.unique(metimage.rsr[det]['wavelength'])
+                if not (wvl.shape == det_wvl.shape) or not np.all(wvl == det_wvl):
+                    LOG.warning("Wavelngth arrays are not the same among detectors")
+                    wvl_is_constant = False
+
+            if wvl_is_constant:
+                arr = wvl
+                dset = grp.create_dataset('wavelength', arr.shape, dtype='f')
+                dset.attrs['unit'] = 'm'
+                dset.attrs['scale'] = 1e-06
+                dset[...] = arr
+
+            # Loop over each detector:
+            for det in metimage.rsr:
+                det_grp = grp.create_group(det)
+                wvl = metimage.rsr[det]['wavelength'][
+                    ~np.isnan(metimage.rsr[det]['wavelength'])]
+                rsp = metimage.rsr[det]['response'][
+                    ~np.isnan(metimage.rsr[det]['wavelength'])]
+                wvl, idx = np.unique(wvl, return_index=True)
+                rsp = np.take(rsp, idx)
+                LOG.debug("wvl.shape: %s", str(wvl.shape))
+                det_grp.attrs[
+                    'central_wavelength'] = get_central_wave(wvl, rsp)
+                if not wvl_is_constant:
+                    arr = wvl
+                    dset = det_grp.create_dataset(
+                        'wavelength', arr.shape, dtype='f')
+                    dset.attrs['unit'] = 'm'
+                    dset.attrs['scale'] = 1e-06
+                    dset[...] = arr
+
+                dset = det_grp.create_dataset('response', rsp.shape, dtype='f')
+                dset[...] = rsp
+
+
+if __name__ == "__main__":
+    for platform_name in ["Metop-SG-A1", ]:
+        generate_metimage_file(platform_name)


### PR DESCRIPTION
This PR adds a script to convert the high resolution SRFs (under export control) in HDF5 format to the pyspectral internal format.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
