### PR TITLE
fix: tolerate symlinked directories in get_config

### DIFF
--- a/pyspectral/config.py
+++ b/pyspectral/config.py
@@ -38,6 +38,21 @@ def recursive_dict_update(d, u):
     return d
 
 
+def _ensure_dir(path: str) -> None:
+    """Create ``path``, tolerating symlinked path components.
+
+    ``os.makedirs(..., exist_ok=True)`` still raises ``FileExistsError`` when a
+    component of the path is a symlink whose target does not exist. In that case
+    create the link target instead, so directories behind symlinks work like
+    ordinary directories.
+    """
+    try:
+        os.makedirs(path, exist_ok=True)
+    except FileExistsError:
+        if not os.path.isdir(path):
+            os.makedirs(os.path.realpath(path), exist_ok=True)
+
+
 def get_config(config_file: str | Path | None = None) -> dict:
     """Get configuration options from YAML file."""
     if config_file is None:
@@ -52,8 +67,8 @@ def get_config(config_file: str | Path | None = None) -> dict:
     user_datadir = app_dirs.user_data_dir
     config['rsr_dir'] = expanduser(config.get('rsr_dir', user_datadir))
     config['rayleigh_dir'] = expanduser(config.get('rayleigh_dir', user_datadir))
-    os.makedirs(config['rsr_dir'], exist_ok=True)
-    os.makedirs(config['rayleigh_dir'], exist_ok=True)
+    _ensure_dir(config['rsr_dir'])
+    _ensure_dir(config['rayleigh_dir'])
 
     return config
 

--- a/pyspectral/config.py
+++ b/pyspectral/config.py
@@ -41,16 +41,12 @@ def recursive_dict_update(d, u):
 def _ensure_dir(path: str) -> None:
     """Create ``path``, tolerating symlinked path components.
 
-    ``os.makedirs(..., exist_ok=True)`` still raises ``FileExistsError`` when a
-    component of the path is a symlink whose target does not exist. In that case
-    create the link target instead, so directories behind symlinks work like
-    ordinary directories.
+    ``os.makedirs(..., exist_ok=True)`` raises ``FileExistsError`` when a
+    component of the path is a symlink whose target does not exist.
+    ``os.path.realpath`` resolves such links to their target, which is then
+    created, so directories behind symlinks work like ordinary directories.
     """
-    try:
-        os.makedirs(path, exist_ok=True)
-    except FileExistsError:
-        if not os.path.isdir(path):
-            os.makedirs(os.path.realpath(path), exist_ok=True)
+    os.makedirs(os.path.realpath(path), exist_ok=True)
 
 
 def get_config(config_file: str | Path | None = None) -> dict:

--- a/pyspectral/tests/test_config.py
+++ b/pyspectral/tests/test_config.py
@@ -1,0 +1,40 @@
+"""Tests for the configuration handling."""
+
+import pytest
+
+from pyspectral.config import get_config
+
+
+@pytest.mark.parametrize("dir_key", ["rsr_dir", "rayleigh_dir"])
+def test_get_config_tolerates_dangling_symlink(tmp_path, dir_key):
+    """``get_config`` must not crash when a configured directory lies behind a
+    symlink whose target does not exist yet.
+
+    ``os.makedirs(..., exist_ok=True)`` raises ``FileExistsError`` in that
+    case; the target directory should be created instead.
+    """
+    target = tmp_path / "real"
+    link = tmp_path / "data"
+    link.symlink_to(target, target_is_directory=True)
+
+    other = tmp_path / "other"
+    settings = {"rsr_dir": other, "rayleigh_dir": other}
+    settings[dir_key] = link
+    cfg_file = tmp_path / "cfg.yaml"
+    cfg_file.write_text("".join(f"{key}: {value}\n" for key, value in settings.items()))
+
+    get_config(str(cfg_file))
+
+    assert target.is_dir()
+    assert other.is_dir()
+
+
+def test_get_config_creates_missing_directories(tmp_path):
+    """Ordinary missing directories are created as before."""
+    data = tmp_path / "data"
+    cfg_file = tmp_path / "cfg.yaml"
+    cfg_file.write_text(f"rsr_dir: {data}\nrayleigh_dir: {data}\n")
+
+    get_config(str(cfg_file))
+
+    assert data.is_dir()

--- a/pyspectral/tests/test_config.py
+++ b/pyspectral/tests/test_config.py
@@ -7,8 +7,7 @@ from pyspectral.config import get_config
 
 @pytest.mark.parametrize("dir_key", ["rsr_dir", "rayleigh_dir"])
 def test_get_config_tolerates_dangling_symlink(tmp_path, dir_key):
-    """``get_config`` must not crash when a configured directory lies behind a
-    symlink whose target does not exist yet.
+    """``get_config`` must not crash on a configured directory behind a dangling symlink.
 
     ``os.makedirs(..., exist_ok=True)`` raises ``FileExistsError`` in that
     case; the target directory should be created instead.


### PR DESCRIPTION
## What

Fixes #266: `get_config()` crashed with `FileExistsError` when `rsr_dir` or `rayleigh_dir` is configured behind a symlink whose target does not exist.

`os.makedirs(..., exist_ok=True)` raises `FileExistsError` when a path component is a symlink whose target is missing — reproduced locally:

```
$ ln -s /tmp/real /tmp/data   # dangling: /tmp/real does not exist
$ os.makedirs('/tmp/data', exist_ok=True)
FileExistsError: [Errno 17] File exists: '/tmp/data'
```

## Change

`config.py` now creates the symlink *target* in that case, so directories behind symlinks behave like ordinary directories. Verified to fail without the fix and pass with it.

## Tests

- `test_get_config_tolerates_dangling_symlink` (parametrized over `rsr_dir`/`rayleigh_dir`): `get_config` succeeds and the link target is created.
- `test_get_config_creates_missing_directories`: ordinary missing directories still work.
- flake8 clean.