### PR TITLE
fix(seviri): include the first IR row when converting RSR data

### DIFF
--- a/pyspectral/tests/test_seviri_rsr.py
+++ b/pyspectral/tests/test_seviri_rsr.py
@@ -1,0 +1,41 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+from xlrd import open_workbook
+
+
+def _import_seviri_module(repo_root: Path):
+    sys.modules.pop("rsr_convert_scripts.seviri_rsr", None)
+    sys.modules["pkg_resources"] = types.SimpleNamespace(
+        resource_filename=lambda package, resource: str(repo_root / "pyspectral" / "data")
+    )
+    return importlib.import_module("rsr_convert_scripts.seviri_rsr")
+
+
+def test_ir_channels_include_the_first_spreadsheet_row(monkeypatch):
+    repo_root = Path(__file__).resolve().parents[2]
+    xls_path = repo_root / "pyspectral" / "data" / "MSG_SEVIRI_Spectral_Response_Characterisation.XLS"
+    workbook = open_workbook(str(xls_path))
+    sheet = workbook.sheet_by_name("IR7.3")
+
+    # The issue's concrete repro: the first wavelength/data row is line 13 in the
+    # spreadsheet UI, which is row index 12 for xlrd.
+    assert sheet.cell_value(12, 0) == 6.35
+    assert sheet.cell_value(13, 0) == 6.37
+
+    seviri_rsr = _import_seviri_module(repo_root)
+    monkeypatch.setattr(
+        seviri_rsr,
+        "get_config",
+        lambda: {
+            "seviri": {"path": str(xls_path), "filename": xls_path.name},
+            "rsr_dir": str(repo_root / "tmp-rsr"),
+        },
+    )
+
+    seviri = seviri_rsr.Seviri()
+
+    assert seviri.rsr["IR7.3"]["wavelength"][0] == sheet.cell_value(12, 0)
+    assert seviri.rsr["IR7.3"]["Meteosat-11"]["95"][0] == sheet.cell_value(12, 7)

--- a/pyspectral/tests/test_seviri_rsr.py
+++ b/pyspectral/tests/test_seviri_rsr.py
@@ -1,3 +1,9 @@
+"""Regression tests for the SEVIRI RSR converter.
+
+Ensures the first spreadsheet row of each IR channel is included when
+converting the bundled MSG SEVIRI spectral response workbook (issue #253).
+"""
+
 import importlib
 import sys
 import types
@@ -15,6 +21,7 @@ def _import_seviri_module(repo_root: Path):
 
 
 def test_ir_channels_include_the_first_spreadsheet_row(monkeypatch):
+    """IR channel RSR data must start at spreadsheet row 12, not row 13."""
     repo_root = Path(__file__).resolve().parents[2]
     xls_path = repo_root / "pyspectral" / "data" / "MSG_SEVIRI_Spectral_Response_Characterisation.XLS"
     workbook = open_workbook(str(xls_path))

--- a/rsr_convert_scripts/seviri_rsr.py
+++ b/rsr_convert_scripts/seviri_rsr.py
@@ -91,23 +91,23 @@ class Seviri(object):
                 self.rsr[ch_name]['Meteosat-11'] = met11
             elif ch_name.startswith('IR'):
                 wvl = np.array(
-                    sheet.col_values(0, start_rowx=13, end_rowx=113))
+                    sheet.col_values(0, start_rowx=12, end_rowx=112))
                 met8_95 = np.array(
-                    sheet.col_values(1, start_rowx=13, end_rowx=113))
+                    sheet.col_values(1, start_rowx=12, end_rowx=112))
                 met9_95 = np.array(
-                    sheet.col_values(3, start_rowx=13, end_rowx=113))
+                    sheet.col_values(3, start_rowx=12, end_rowx=112))
                 met10_95 = np.array(
-                    sheet.col_values(5, start_rowx=13, end_rowx=113))
+                    sheet.col_values(5, start_rowx=12, end_rowx=112))
                 met11_95 = np.array(
-                    sheet.col_values(7, start_rowx=13, end_rowx=113))
+                    sheet.col_values(7, start_rowx=12, end_rowx=112))
                 met8_85 = np.array(
-                    sheet.col_values(2, start_rowx=13, end_rowx=113))
+                    sheet.col_values(2, start_rowx=12, end_rowx=112))
                 met9_85 = np.array(
-                    sheet.col_values(4, start_rowx=13, end_rowx=113))
+                    sheet.col_values(4, start_rowx=12, end_rowx=112))
                 met10_85 = np.array(
-                    sheet.col_values(6, start_rowx=13, end_rowx=113))
+                    sheet.col_values(6, start_rowx=12, end_rowx=112))
                 met11_85 = np.array(
-                    sheet.col_values(8, start_rowx=13, end_rowx=113))
+                    sheet.col_values(8, start_rowx=12, end_rowx=112))
                 self.rsr[ch_name]['Meteosat-8'] = {'95': met8_95,
                                                    '85': met8_85}
                 self.rsr[ch_name]['Meteosat-9'] = {'95': met9_95,


### PR DESCRIPTION
## What

Fixes #253: the SEVIRI RSR converter skips the first IR spreadsheet data row. The issue report was correct: `xlrd` is 0-indexed, so spreadsheet line 13 corresponds to `start_rowx=12`, not `13`.

For `IR7.3` in the bundled workbook, row 12 starts at wavelength `6.35`, while the current loader starts at row 13 and incorrectly begins at `6.37`.

## Change

In `rsr_convert_scripts/seviri_rsr.py`, the IR-channel branch now reads rows `12..111` instead of `13..112` for the wavelength column and every Meteosat response column.

## Verification

- Workbook proof from `pyspectral/data/MSG_SEVIRI_Spectral_Response_Characterisation.XLS`:
  - row 12 col 0 = `6.35`
  - row 13 col 0 = `6.37`
- New regression test `test_ir_channels_include_the_first_spreadsheet_row`
  - **fails before the fix**: loaded first wavelength is `6.37`
  - passes after the fix
- Test runs:
  - `.venv/bin/python -m pytest pyspectral/tests/test_seviri_rsr.py pyspectral/tests/test_config.py -q` -> **4 passed**
  - `.venv/bin/flake8 rsr_convert_scripts/seviri_rsr.py pyspectral/tests/test_seviri_rsr.py pyspectral/tests/test_config.py` -> **passed**

## Why this is scoped correctly

This change only touches the IR-specific row window in the shared loader path. The non-IR channels already use `start_rowx=12`, and HRV uses a different block entirely.
